### PR TITLE
Fixed activator trigger bug for hostname

### DIFF
--- a/fabric_rti_mcp/activator/activator_entity_generators.py
+++ b/fabric_rti_mcp/activator/activator_entity_generators.py
@@ -79,6 +79,13 @@ def create_kql_source_entity(
     
     kql_source_id = str(uuid.uuid4())
 
+    # Extract hostname from URL if provided
+    # Strip https://, http://, and trailing /
+    if cluster_hostname:
+        hostname = cluster_hostname.replace("https://", "")
+        hostname = hostname.replace("http://", "")
+        cluster_hostname = hostname.rstrip("/")
+    
     # Strip newlines from KQL query as the API does not handle it properly
     kql_query = kql_query.replace("\n", " ").replace(" ", " ")
 


### PR DESCRIPTION
When I was trying to create activator triggers on various clusters I was running into a KQLSource issue. This was due to the hostname being provided that I copy pasted into my environment had https:// in the beginning but the tool expects this part to be stripped. This little fix solved my agent to create a trigger properly.