### PR TITLE
Kusto return exceeds limits fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,12 +202,37 @@ None - the server will work with default settings for demo purposes.
 |----------|---------|-------------|---------|---------|
 | `KUSTO_SERVICE_URI` | Kusto | Default Kusto cluster URI | None | `https://mycluster.westus.kusto.windows.net` |
 | `KUSTO_SERVICE_DEFAULT_DB` | Kusto | Default database name for Kusto queries | `NetDefaultDB` | `MyDatabase` |
+| `KUSTO_MAX_RESULT_ROWS` | Kusto | Maximum number of rows to return from queries (prevents Azure AI Agents 1MB output limit errors) | `10000` | `5000` |
 | `AZ_OPENAI_EMBEDDING_ENDPOINT` | Kusto | Azure OpenAI embedding endpoint for semantic search in `kusto_get_shots` | None | `https://your-resource.openai.azure.com/openai/deployments/text-embedding-ada-002/embeddings?api-version=2024-10-21;impersonate` |
 | `KUSTO_KNOWN_SERVICES` | Kusto | JSON array of preconfigured Kusto services | None | `[{"service_uri":"https://cluster1.kusto.windows.net","default_database":"DB1","description":"Prod"}]` |
 | `KUSTO_EAGER_CONNECT` | Kusto | Whether to eagerly connect to default service on startup (not recommended) | `false` | `true` or `false` |
 | `KUSTO_ALLOW_UNKNOWN_SERVICES` | Kusto | Security setting to allow connections to services not in `KUSTO_KNOWN_SERVICES` | `true` | `true` or `false` |
 | `FABRIC_API_BASE` | Global | Base URL for Microsoft Fabric API | `https://api.fabric.microsoft.com/v1` | `https://api.fabric.microsoft.com/v1` |
 | `FABRIC_BASE_URL` | Global | Base URL for Microsoft Fabric web interface | `https://fabric.microsoft.com` | `https://fabric.microsoft.com` |
+
+### Result Truncation
+
+The `KUSTO_MAX_RESULT_ROWS` setting helps prevent output size limit errors when using AI agents. When a query returns more rows than this limit:
+
+- **Automatic Truncation**: Results are automatically truncated to the configured limit
+- **Metadata Added**: The response includes `_truncated`, `_original_row_count`, `_returned_row_count`, and `_truncation_message` fields
+- **Warning Logged**: A warning is logged with the correlation ID for troubleshooting
+- **Best Practice**: Set this to match your AI agent's output limits (e.g., Azure AI Agents has a 1MB limit)
+- **Disable**: Set to `0` to disable truncation (not recommended for AI agents)
+
+**Example truncated response metadata:**
+```json
+{
+  "format": "columnar",
+  "data": { ... },
+  "_truncated": true,
+  "_original_row_count": 25000,
+  "_returned_row_count": 10000,
+  "_truncation_message": "Result truncated: showing 10000 of 25000 rows. Use '| take 10000' or '| limit 10000' in your query for better control."
+}
+```
+
+> **Tip**: For better control, use `| take N` or `| limit N` directly in your KQL queries instead of relying on automatic truncation.
 
 ### Embedding Endpoint Configuration
 

--- a/fabric_rti_mcp/activator/activator_entity_generators.py
+++ b/fabric_rti_mcp/activator/activator_entity_generators.py
@@ -79,6 +79,13 @@ def create_kql_source_entity(
     
     kql_source_id = str(uuid.uuid4())
 
+    # Extract hostname from URL if provided
+    # Strip https://, http://, and trailing /
+    if cluster_hostname:
+        hostname = cluster_hostname.replace("https://", "")
+        hostname = hostname.replace("http://", "")
+        cluster_hostname = hostname.rstrip("/")
+    
     # Strip newlines from KQL query as the API does not handle it properly
     kql_query = kql_query.replace("\n", " ").replace(" ", " ")
 

--- a/fabric_rti_mcp/kusto/kusto_config.py
+++ b/fabric_rti_mcp/kusto/kusto_config.py
@@ -25,6 +25,7 @@ class KustoEnvVarNames:
     eager_connect = "KUSTO_EAGER_CONNECT"
     allow_unknown_services = "KUSTO_ALLOW_UNKNOWN_SERVICES"
     timeout = "FABRIC_RTI_KUSTO_TIMEOUT"
+    max_result_rows = "KUSTO_MAX_RESULT_ROWS"
 
     @staticmethod
     def all() -> List[str]:
@@ -37,6 +38,7 @@ class KustoEnvVarNames:
             KustoEnvVarNames.eager_connect,
             KustoEnvVarNames.allow_unknown_services,
             KustoEnvVarNames.timeout,
+            KustoEnvVarNames.max_result_rows,
         ]
 
 
@@ -56,6 +58,10 @@ class KustoConfig:
     allow_unknown_services: bool = True
     # Global timeout for all Kusto operations in seconds
     timeout_seconds: Optional[int] = None
+    # Maximum number of rows to return from query results.
+    # Default is 10000 to stay well within Azure AI Agents 1MB limit.
+    # Set to 0 to disable truncation (not recommended for AI agents).
+    max_result_rows: int = 10000
 
     @staticmethod
     def from_env() -> KustoConfig:
@@ -86,6 +92,16 @@ class KustoConfig:
                 # Ignore invalid timeout values
                 pass
 
+        # Parse max result rows configuration
+        max_result_rows = 10000  # Default to 10k rows
+        max_rows_env = os.getenv(KustoEnvVarNames.max_result_rows)
+        if max_rows_env:
+            try:
+                max_result_rows = int(max_rows_env)
+            except ValueError:
+                # Ignore invalid values, keep default
+                pass
+
         if known_services_string:
             try:
                 known_services_json = json.loads(known_services_string)
@@ -100,6 +116,7 @@ class KustoConfig:
             eager_connect,
             allow_unknown_services,
             timeout_seconds,
+            max_result_rows,
         )
 
     @staticmethod


### PR DESCRIPTION
The kusto MCP tools do not currently have any limits which results in MCP tool returning data sizes that are much higher than allowed by the Azure Open AI endpoints resulting in errors and rate limiting by the endpoints. I added a new function that lets the user customize the return size by length of rows. I'm not sure if this is the best solution but it worked well in my testing.