### PR TITLE
Enable "foundry compat schema" by default

### DIFF
--- a/fabric_rti_mcp/config/__init__.py
+++ b/fabric_rti_mcp/config/__init__.py
@@ -103,10 +103,16 @@ class GlobalFabricRTIConfig:
         parser.add_argument("--http", action="store_true", help="Use HTTP transport")
         parser.add_argument("--host", type=str, help="HTTP host to listen on")
         parser.add_argument("--port", type=int, help="HTTP port to listen on")
-        parser.add_argument("--stateless-http", action="store_true", help="Enable or disable stateless HTTP")
-        parser.add_argument("--use-obo-flow", action="store_true", help="Enable or disable OBO flow")
         parser.add_argument(
-            "--use-ai-foundry-compat", action="store_true", help="Enable or disable AI Foundry compatibility mode"
+            "--stateless-http", action=argparse.BooleanOptionalAction, help="Enable or disable stateless HTTP"
+        )
+        parser.add_argument(
+            "--use-obo-flow", action=argparse.BooleanOptionalAction, help="Enable or disable OBO flow"
+        )
+        parser.add_argument(
+            "--use-ai-foundry-compat",
+            action=argparse.BooleanOptionalAction,
+            help="Enable or disable AI Foundry compatibility mode",
         )
         args, _ = parser.parse_known_args()
 


### PR DESCRIPTION
Since newest version of VS code, a feature called "strict schema validation" has been enabled. Whenever the create_trigger Activator tool is used with a Claude model, it hits this error:
<img width="570" height="245" alt="image" src="https://github.com/user-attachments/assets/40e1787b-36f1-4197-9bd1-fe6afef61b04" />

This is despite the schema being returned by the tool is valid (and contains the appropriate sub-definition). It seems that Claude models may not  support sub-definitions right now during strict-schema validation. 

This PR enables the "foundry-compat-schema" mode by default as that has proven to fix the issue by inlining the sub-defs 

(Also, slight tweak to the argument parsing. `store_true` always returns True or False, never None. So the values from `base_config` were always being overridden) 