### PR TITLE
Add some "usage information" to internal description of Activator rule

### DIFF
--- a/fabric_rti_mcp/services/activator/activator_entity_generators.py
+++ b/fabric_rti_mcp/services/activator/activator_entity_generators.py
@@ -175,7 +175,7 @@ def create_simple_event_rule_entities(
         "uniqueIdentifier": rule_id,
         "payload": {
             "name": f"{trigger_name} rule",
-            "description": "Created by: RTI-MCP",
+            "description": "Created by: rti-mcp-py",
             "parentContainer": {"targetUniqueIdentifier": container_id},
             "definition": {
                 "type": "Rule",


### PR DESCRIPTION
In https://github.com/microsoft/fabric-rti-mcp/pull/85/files, an attempt was made to track usage telemetry from Activator trigger creation. 

However, unfortunately the shared-fabric-platform does not currently propagate HTTP headers to the workload. We are discussing with Fabric platform team to change that, but realistically that will be on the order of months, if it happens at all. 

In the meantime, this PR puts some usage info into an internal description field in the request body that we will parse on the backend. 