### PR TITLE
Remove indirect reference from Activator tool's KQL source type

### DIFF
--- a/fabric_rti_mcp/services/activator/activator_service.py
+++ b/fabric_rti_mcp/services/activator/activator_service.py
@@ -2,44 +2,12 @@ import base64
 import json
 from typing import Any, cast
 
-from pydantic import BaseModel, Field
-
 from fabric_rti_mcp.config import GlobalFabricRTIConfig
 from fabric_rti_mcp.fabric_api_http_client import FabricHttpClientCache
 from fabric_rti_mcp.services.activator import activator_entity_generators
 
 # Microsoft Fabric API configuration
 FABRIC_CONFIG = GlobalFabricRTIConfig.from_env()
-
-
-# Pydantic models for source types
-class SourceBase(BaseModel):
-    """Base class for all activator source types."""
-
-    source_type: str = Field(..., description="The type of source (e.g., 'kql', 'eventstream')")
-
-
-class KqlSource(SourceBase):
-    """KQL source configuration for activator triggers."""
-
-    source_type: str = Field(default="kql", description="Source type identifier")
-    cluster_url: str = Field(..., description="The KQL cluster URL")
-    database: str = Field(..., description="The KQL database name")
-    query: str = Field(
-        ...,
-        description="The KQL query to monitor. "
-        "The query MUST be appropriate for the schema of the underlying data, "
-        "otherwise the alert will not function correctly",
-    )
-    polling_frequency_minutes: int = Field(
-        default=5,
-        description="Polling frequency in minutes. Must be one of: 5, 15, 60, 180, 360, 720, 1440 (defaults to 5)",
-        ge=1,
-        le=1440,
-    )
-
-    class Config:
-        extra = "forbid"
 
 
 class ActivatorService:
@@ -80,11 +48,14 @@ class ActivatorService:
         self,
         workspace_id: str,
         trigger_name: str,
-        source: KqlSource,
+        kql_cluster_url: str,
+        kql_database: str,
+        kql_query: str,
         alert_recipient: str,
         alert_message: str,
         alert_headline: str,
         alert_type: str = "teams",
+        kql_polling_frequency_minutes: int = 5,
         artifact_id: str | None = None,
     ) -> dict[str, Any]:
         """
@@ -92,13 +63,18 @@ class ActivatorService:
 
         :param workspace_id: The workspace ID (UUID)
         :param trigger_name: Name of the trigger
-        :param source: Source configuration (e.g., KqlSource)
+        :param kql_cluster_url: The KQL cluster URL
+        :param kql_database: The KQL database name
+        :param kql_query: The KQL query to monitor. The query MUST be appropriate for the schema of the underlying
+            data, otherwise the alert will not function correctly
         :param alert_recipient: Email address of the alert recipient
-        :param alert_type: Type of alert - "teams" or "email" (defaults to "teams")
         :param alert_message: Alert message for the trigger
         :param alert_headline: Alert headline for the trigger
+        :param alert_type: Type of alert - "teams" or "email" (defaults to "teams")
+        :param kql_polling_frequency_minutes: Polling frequency in minutes. Must be one of: 5, 15, 60, 180, 360, 720,
+            1440 (defaults to 5)
         :param artifact_id: If specified, the trigger will be created in the specified Activator artifact.
-        If left blank, a new Activator artifact will be created.
+            If left blank, a new Activator artifact will be created.
         :return: Created trigger details:
             * url: URL back to the trigger in Fabric UI for further management
             * id: Artifact ID if a new one was created
@@ -110,19 +86,15 @@ class ActivatorService:
         """
         (container_entity, container_guid) = activator_entity_generators.create_container_entity(trigger_name)
 
-        # Handle different source types
-        if isinstance(source, KqlSource):  # type: ignore
-            (source_entity, source_guid) = activator_entity_generators.create_kql_source_entity(
-                trigger_name,
-                polling_frequency_minutes=source.polling_frequency_minutes,
-                kql_query=source.query,
-                database=source.database,
-                cluster_hostname=source.cluster_url,
-                container_id=container_guid,
-                workspace_id=workspace_id,
-            )
-        else:
-            raise ValueError(f"Unsupported source type: {type(source)}")
+        (source_entity, source_guid) = activator_entity_generators.create_kql_source_entity(
+            trigger_name,
+            polling_frequency_minutes=kql_polling_frequency_minutes,
+            kql_query=kql_query,
+            database=kql_database,
+            cluster_hostname=kql_cluster_url,
+            container_id=container_guid,
+            workspace_id=workspace_id,
+        )
 
         return self._create_trigger_with_source(
             workspace_id=workspace_id,

--- a/tests/live/test_activator_service.py
+++ b/tests/live/test_activator_service.py
@@ -11,7 +11,7 @@ from typing import Any
 # Add the project root to the path so we can import the service
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
 
-from fabric_rti_mcp.services.activator.activator_service import DEFAULT_ACTIVATOR_SERVICE, KqlSource
+from fabric_rti_mcp.services.activator.activator_service import DEFAULT_ACTIVATOR_SERVICE
 
 
 def create_email_trigger_new_artifact(
@@ -57,18 +57,13 @@ def create_email_trigger_new_artifact(
     print()
 
     try:
-        # Create KQL source model
-        kql_source = KqlSource(
-            cluster_url=kql_cluster_url,
-            database=kql_database,
-            query=kql_query,
-            polling_frequency_minutes=polling_frequency_in_minutes,
-        )
-
         email_result = DEFAULT_ACTIVATOR_SERVICE.activator_create_trigger(
             workspace_id=workspace_id,
             trigger_name=email_trigger_name,
-            source=kql_source,
+            kql_cluster_url=kql_cluster_url,
+            kql_database=kql_database,
+            kql_query=kql_query,
+            kql_polling_frequency_minutes=polling_frequency_in_minutes,
             alert_recipient=alert_recipient,
             alert_type="email",
             artifact_id=None,  # Create new artifact
@@ -145,18 +140,13 @@ def create_teams_trigger_existing_artifact(
     print()
 
     try:
-        # Create KQL source model
-        kql_source = KqlSource(
-            cluster_url=kql_cluster_url,
-            database=kql_database,
-            query=kql_query,
-            polling_frequency_minutes=polling_frequency_in_minutes,
-        )
-
         teams_result = DEFAULT_ACTIVATOR_SERVICE.activator_create_trigger(
             workspace_id=workspace_id,
             trigger_name=teams_trigger_name,
-            source=kql_source,
+            kql_cluster_url=kql_cluster_url,
+            kql_database=kql_database,
+            kql_query=kql_query,
+            kql_polling_frequency_minutes=polling_frequency_in_minutes,
             alert_recipient=alert_recipient,
             alert_type="teams",
             artifact_id=artifact_id,  # Add to existing artifact


### PR DESCRIPTION
Since newest version of VS code, a feature called "strict schema validation" has been enabled. Whenever the create_trigger Activator tool is used with a Claude model, it hits this error:
<img width="570" height="245" alt="image" src="https://github.com/user-attachments/assets/47864783-2a5f-45f5-b7db-ee282eb185fa" />

This is despite the schema being returned by the tool is valid (and contains the appropriate sub-definition). It seems that Claude models may not support sub-definitions right now during strict-schema validation.

This PR removes the sub-schemas from the Activator tool since they are currently not needed. 

Testing done:
* All unit tests
* Activator live tests
* Manually creating trigger via agent in VS code