### PR TITLE
feat: add show_stats parameter to kusto_query and kusto_graph_query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Release History
 
 ## 0.0.10 (Unreleased)
+### Features
+- **Kusto query statistics**: Add optional `show_stats` parameter to `kusto_query` and `kusto_graph_query`. When `True`, the response includes a top-level `statistics` key with execution time, CPU, memory, cache, network, extents/rows scanned, result size, and per-cluster cross-cluster breakdown — extracted from the `QueryCompletionInformation` tables returned by the SDK.
+
 ### Other Changes
 - Use docstring as tool description
 - Add annotations (readonly, destructive)


### PR DESCRIPTION
## Summary

Add an opt-in `show_stats: bool = False` parameter to `kusto_query` and `kusto_graph_query`. When `True`, execution statistics from the Kusto SDK's `QueryCompletionInformation` tables are included as a top-level `statistics` key in the tool response.

Default is `False` — fully non-breaking change.

Fixes #122

## What's included

- `show_stats: bool = False` parameter on both `kusto_query` and `kusto_graph_query`
- Statistics extracted from `QueryCompletionInformation` tables via the SDK
- Response shape when `show_stats=True`:
  ```json
  {
    "results": [...],
    "statistics": {
      "execution_time": {"server_cpu": 0.123, "total": 0.456},
      "memory": {"peak_memory_mb": 12.3},
      "cache": {"hot_hits": 10, "cold_hits": 2, "misses": 0},
      "network": {"inter_cluster_total_bytes": 0},
      "extents": {"scanned": 5, "deleted": 0, "orphaned": 0},
      "rows_scanned": 10000,
      "result_size_bytes": 2048,
      "cross_cluster_breakdown": []
    }
  }
  ```

## Motivation

Enables query optimisation agents (e.g. an `optimize.prompt.md` workflow) to understand query cost and guide KQL improvements without a separate profiling step.

Related prior art: https://github.com/microsoft/mcp/pull/1787

## Checklist
- [x] `make precommit` passes (63 tests)
- [x] Default is `False` (non-breaking)
- [x] Tests cover both `show_stats=True` and `show_stats=False` paths
