### PR TITLE
Add Kusto Web Explorer deeplink to query results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Release History
 
 ## 0.0.10 (Unreleased)
+### Features
+- Added Kusto Web Explorer deeplink URL to `kusto_query` responses, enabling one-click access to open queries in the Azure Data Explorer Web UI. Supports public, US Government, and China cloud endpoints.
+
 ### Other Changes
 - Use docstring as tool description
 - Add annotations (readonly, destructive)

--- a/fabric_rti_mcp/services/kusto/kusto_deeplink.py
+++ b/fabric_rti_mcp/services/kusto/kusto_deeplink.py
@@ -1,0 +1,69 @@
+import base64
+import gzip
+from urllib.parse import quote, urlparse
+
+_MAX_URL_LENGTH = 8000
+
+_PUBLIC_EXPLORER_BASE = "https://dataexplorer.azure.com"
+_US_GOV_EXPLORER_BASE = "https://dataexplorer.azure.us"
+_CHINA_EXPLORER_BASE = "https://dataexplorer.azure.cn"
+
+# Cloud domain suffix → Web Explorer base URL mapping.
+# Order doesn't matter; we check all suffixes.
+_CLOUD_MAPPINGS: list[tuple[str, str]] = [
+    # Public cloud
+    (".kusto.windows.net", _PUBLIC_EXPLORER_BASE),
+    (".kustodev.windows.net", _PUBLIC_EXPLORER_BASE),
+    (".kustomfa.windows.net", _PUBLIC_EXPLORER_BASE),
+    (".kusto.data.microsoft.com", _PUBLIC_EXPLORER_BASE),
+    (".kusto.fabric.microsoft.com", _PUBLIC_EXPLORER_BASE),
+    (".kusto.azuresynapse.net", _PUBLIC_EXPLORER_BASE),
+    # US Government
+    (".kusto.usgovcloudapi.net", _US_GOV_EXPLORER_BASE),
+    (".kustomfa.usgovcloudapi.net", _US_GOV_EXPLORER_BASE),
+    # China
+    (".kusto.chinacloudapi.cn", _CHINA_EXPLORER_BASE),
+    (".kustomfa.chinacloudapi.cn", _CHINA_EXPLORER_BASE),
+    (".kusto.azuresynapse.azure.cn", _CHINA_EXPLORER_BASE),
+]
+
+
+def _get_explorer_base_url(host: str) -> str | None:
+    host_lower = host.lower()
+    for suffix, explorer_base in _CLOUD_MAPPINGS:
+        if host_lower.endswith(suffix):
+            return explorer_base
+    return None
+
+
+def build_web_explorer_url(cluster_uri: str, database: str, query: str) -> str | None:
+    """
+    Build a Kusto Web Explorer deeplink URL that opens the given query in the
+    Azure Data Explorer Web UI.
+
+    Returns None if the cluster URI is invalid, the domain is unrecognized, or
+    the resulting URL exceeds 8000 characters.
+    """
+    try:
+        parsed = urlparse(cluster_uri)
+        if not parsed.scheme or not parsed.hostname:
+            return None
+    except Exception:
+        return None
+
+    host = parsed.hostname
+    explorer_base = _get_explorer_base_url(host)
+    if explorer_base is None:
+        return None
+
+    query_bytes = query.encode("utf-8")
+    compressed = gzip.compress(query_bytes)
+    b64 = base64.b64encode(compressed).decode("ascii")
+    url_encoded = quote(b64, safe="")
+
+    url = f"{explorer_base}/clusters/{host}/databases/{database}?query={url_encoded}"
+
+    if len(url) > _MAX_URL_LENGTH:
+        return None
+
+    return url

--- a/fabric_rti_mcp/services/kusto/kusto_service.py
+++ b/fabric_rti_mcp/services/kusto/kusto_service.py
@@ -13,6 +13,7 @@ from fabric_rti_mcp import __version__  # type: ignore
 from fabric_rti_mcp.config import logger
 from fabric_rti_mcp.services.kusto.kusto_config import KustoConfig
 from fabric_rti_mcp.services.kusto.kusto_connection import KustoConnection, sanitize_uri
+from fabric_rti_mcp.services.kusto.kusto_deeplink import build_web_explorer_url
 from fabric_rti_mcp.services.kusto.kusto_formatter import KustoFormatter
 
 
@@ -207,9 +208,14 @@ def kusto_query(
     :param cluster_uri: The URI of the Kusto cluster.
     :param database: Optional database name. If not provided, uses the default database.
     :param client_request_properties: Optional dictionary of additional client request properties.
-    :return: The result of the query execution as a list of dictionaries (json).
+    :return: The result of the query execution as a dict with format, data, and web_explorer_url.
+        web_explorer_url is a deeplink to open the query in Azure Data Explorer Web UI,
+        or null if the cluster domain is unrecognized.
     """
-    return _execute(query, cluster_uri, database=database, client_request_properties=client_request_properties)
+    result = _execute(query, cluster_uri, database=database, client_request_properties=client_request_properties)
+    resolved_database = database or get_kusto_connection(cluster_uri).default_database
+    result["web_explorer_url"] = build_web_explorer_url(cluster_uri, resolved_database, query.strip())
+    return result
 
 
 def kusto_graph_query(

--- a/tests/unit/kusto/test_kusto_deeplink.py
+++ b/tests/unit/kusto/test_kusto_deeplink.py
@@ -1,0 +1,79 @@
+import base64
+import gzip
+
+import pytest
+
+from fabric_rti_mcp.services.kusto.kusto_deeplink import build_web_explorer_url
+
+
+def _decode_query_from_url(url: str) -> str:
+    """Roundtrip decode: extract query param → URL-decode → base64-decode → gzip-decompress → UTF-8."""
+    from urllib.parse import unquote, urlparse, parse_qs
+
+    parsed = urlparse(url)
+    encoded = parse_qs(parsed.query)["query"][0]
+    compressed = base64.b64decode(encoded)
+    return gzip.decompress(compressed).decode("utf-8")
+
+
+def test_simple_query_produces_valid_url() -> None:
+    url = build_web_explorer_url("https://help.kusto.windows.net", "Samples", "StormEvents | take 10")
+
+    assert url is not None
+    assert url.startswith("https://dataexplorer.azure.com/clusters/help.kusto.windows.net/databases/Samples?query=")
+    assert _decode_query_from_url(url) == "StormEvents | take 10"
+
+
+def test_regional_cluster_produces_valid_url() -> None:
+    url = build_web_explorer_url("https://mycluster.westus.kusto.windows.net", "MyDb", "MyTable | count")
+
+    assert url is not None
+    assert url.startswith(
+        "https://dataexplorer.azure.com/clusters/mycluster.westus.kusto.windows.net/databases/MyDb?query="
+    )
+
+
+def test_us_gov_cloud_uses_correct_explorer_base() -> None:
+    url = build_web_explorer_url("https://mycluster.kusto.usgovcloudapi.net", "db1", "T | take 1")
+
+    assert url is not None
+    assert url.startswith(
+        "https://dataexplorer.azure.us/clusters/mycluster.kusto.usgovcloudapi.net/databases/db1?query="
+    )
+
+
+def test_china_cloud_uses_correct_explorer_base() -> None:
+    url = build_web_explorer_url("https://mycluster.kusto.chinacloudapi.cn", "db1", "T | take 1")
+
+    assert url is not None
+    assert url.startswith(
+        "https://dataexplorer.azure.cn/clusters/mycluster.kusto.chinacloudapi.cn/databases/db1?query="
+    )
+
+
+def test_query_exceeding_max_length_returns_none() -> None:
+    # Incrementing hex values resist gzip compression well
+    long_query = "".join(f"{i:04X}" for i in range(10000))
+
+    url = build_web_explorer_url("https://help.kusto.windows.net", "Samples", long_query)
+
+    assert url is None
+
+
+def test_invalid_uri_returns_none() -> None:
+    url = build_web_explorer_url("not-a-uri", "db", "query")
+
+    assert url is None
+
+
+def test_unsupported_domain_returns_none() -> None:
+    url = build_web_explorer_url("https://example.com", "db", "query")
+
+    assert url is None
+
+
+def test_trailing_slash_produces_valid_url() -> None:
+    url = build_web_explorer_url("https://help.kusto.windows.net/", "Samples", "StormEvents | take 10")
+
+    assert url is not None
+    assert url.startswith("https://dataexplorer.azure.com/clusters/help.kusto.windows.net/databases/Samples?query=")

--- a/tests/unit/kusto/test_kusto_service.py
+++ b/tests/unit/kusto/test_kusto_service.py
@@ -33,7 +33,7 @@ def test_execute_basic_query(
     result = kusto_query(query, sample_cluster_uri, database=database)
 
     # Assert
-    mock_get_kusto_connection.assert_called_once_with(sample_cluster_uri)
+    mock_get_kusto_connection.assert_called_with(sample_cluster_uri)
     mock_client.execute.assert_called_once()
 
     # Verify database and stripped query
@@ -51,6 +51,10 @@ def test_execute_basic_query(
     # Verify result format
     assert result["format"] == "columnar"
     assert result["data"]["TestColumn"][0] == "TestValue"
+
+    # Verify deeplink is present for .kusto.windows.net cluster
+    assert result["web_explorer_url"] is not None
+    assert result["web_explorer_url"].startswith("https://dataexplorer.azure.com/clusters/test.kusto.windows.net/databases/test_db?query=")
 
 
 @patch("fabric_rti_mcp.services.kusto.kusto_service.get_kusto_connection")


### PR DESCRIPTION
## What does this PR do?

Adds a `web_explorer_url` field to every `kusto_query` response, providing a one-click deeplink to open the same query in the Azure Data Explorer Web UI.

**How it works:**
- The query text is encoded via UTF-8 → gzip → base64 → URL-encode (matching the ADX Web UI deeplink format)
- Cloud-aware: maps cluster domain suffixes to the correct Web Explorer instance (public `dataexplorer.azure.com`, US Gov `dataexplorer.azure.us`, China `dataexplorer.azure.cn`)
- URLs exceeding 8,000 chars are silently omitted (browser limit)
- Always-on with zero overhead — no extra API calls, just in-memory encoding
- Gracefully returns `null` for unrecognized cloud domains

**Files changed:**
- `kusto_deeplink.py` — new helper module for URL generation with cloud endpoint mapping
- `kusto_service.py` — builds and includes deeplink in `kusto_query` response
- `test_kusto_deeplink.py` — 8 unit tests covering all clouds, roundtrip decoding, max length, invalid inputs
- `test_kusto_service.py` — updated to verify `web_explorer_url` presence
- `CHANGELOG.md` — documents the new feature

Resolves #124

**Reference:** Ports the feature from the C# Azure MCP Server in [microsoft/mcp#1788](https://github.com/microsoft/mcp/pull/1788).