### PR TITLE
fix: convert servertimeout to timedelta in client_request_properties

### DIFF
--- a/fabric_rti_mcp/services/kusto/kusto_service.py
+++ b/fabric_rti_mcp/services/kusto/kusto_service.py
@@ -122,53 +122,35 @@ def destructive_operation(func: F) -> F:
     return wrapper  # type: ignore
 
 
-def _parse_timespan_to_timedelta(value: Any) -> timedelta:
-    """Convert a timespan string or numeric value to a timedelta.
+_TIMESPAN_RE = re.compile(r"^(\d+):(\d+):(\d+)$")
 
-    The Azure Kusto SDK expects ``servertimeout`` to be a ``timedelta`` object
-    (it performs arithmetic with it in ``client_base.py``).  Users, however,
-    commonly pass strings like ``"00:03:00"`` or ``"3m"`` via
-    ``client_request_properties``.  This helper bridges that gap.
+
+def _parse_timespan_to_timedelta(value: Any) -> timedelta:
+    """Convert a timespan value to a timedelta for the Azure Kusto SDK.
+
+    The SDK expects ``servertimeout`` to be a ``timedelta`` object
+    (it performs arithmetic with it in ``client_base.py``).
 
     Supported formats:
     - ``timedelta`` — returned as-is.
     - ``int`` / ``float`` — interpreted as seconds.
-    - ``"HH:MM:SS"`` or ``"H:MM:SS"`` — standard timespan.
-    - ``"Xh"`` / ``"Xm"`` / ``"Xs"`` — shorthand.
-    - Numeric string — interpreted as seconds.
+    - ``"HH:MM:SS"`` — standard timespan string.
     """
     if isinstance(value, timedelta):
         return value
     if isinstance(value, (int, float)):
         return timedelta(seconds=value)
     if isinstance(value, str):
-        text = value.strip()
-        # "HH:MM:SS" or "H:MM:SS"
-        match = re.match(r"^(\d+):(\d+):(\d+)$", text)
+        match = _TIMESPAN_RE.match(value.strip())
         if match:
             return timedelta(
                 hours=int(match.group(1)),
                 minutes=int(match.group(2)),
                 seconds=int(match.group(3)),
             )
-        # Shorthand: "3m", "180s", "1h"
-        match = re.match(r"^(\d+)\s*([hms])$", text, re.IGNORECASE)
-        if match:
-            amount = int(match.group(1))
-            unit = match.group(2).lower()
-            if unit == "h":
-                return timedelta(hours=amount)
-            if unit == "m":
-                return timedelta(minutes=amount)
-            return timedelta(seconds=amount)
-        # Plain numeric string
-        try:
-            return timedelta(seconds=float(text))
-        except ValueError:
-            pass
     raise ValueError(
         f"Cannot parse servertimeout value: {value!r}. "
-        "Use a timedelta, 'HH:MM:SS', 'Xm', 'Xs', 'Xh', or numeric seconds."
+        "Use a timedelta, 'HH:MM:SS', or numeric seconds."
     )
 
 

--- a/fabric_rti_mcp/services/kusto/kusto_service.py
+++ b/fabric_rti_mcp/services/kusto/kusto_service.py
@@ -2,9 +2,11 @@ from __future__ import annotations
 
 import functools
 import inspect
+import re
 import uuid
 from collections.abc import Callable
 from dataclasses import asdict
+from datetime import timedelta
 from typing import Any, TypeVar
 
 from azure.kusto.data import ClientRequestProperties, KustoConnectionStringBuilder
@@ -120,6 +122,56 @@ def destructive_operation(func: F) -> F:
     return wrapper  # type: ignore
 
 
+def _parse_timespan_to_timedelta(value: Any) -> timedelta:
+    """Convert a timespan string or numeric value to a timedelta.
+
+    The Azure Kusto SDK expects ``servertimeout`` to be a ``timedelta`` object
+    (it performs arithmetic with it in ``client_base.py``).  Users, however,
+    commonly pass strings like ``"00:03:00"`` or ``"3m"`` via
+    ``client_request_properties``.  This helper bridges that gap.
+
+    Supported formats:
+    - ``timedelta`` — returned as-is.
+    - ``int`` / ``float`` — interpreted as seconds.
+    - ``"HH:MM:SS"`` or ``"H:MM:SS"`` — standard timespan.
+    - ``"Xh"`` / ``"Xm"`` / ``"Xs"`` — shorthand.
+    - Numeric string — interpreted as seconds.
+    """
+    if isinstance(value, timedelta):
+        return value
+    if isinstance(value, (int, float)):
+        return timedelta(seconds=value)
+    if isinstance(value, str):
+        text = value.strip()
+        # "HH:MM:SS" or "H:MM:SS"
+        match = re.match(r"^(\d+):(\d+):(\d+)$", text)
+        if match:
+            return timedelta(
+                hours=int(match.group(1)),
+                minutes=int(match.group(2)),
+                seconds=int(match.group(3)),
+            )
+        # Shorthand: "3m", "180s", "1h"
+        match = re.match(r"^(\d+)\s*([hms])$", text, re.IGNORECASE)
+        if match:
+            amount = int(match.group(1))
+            unit = match.group(2).lower()
+            if unit == "h":
+                return timedelta(hours=amount)
+            if unit == "m":
+                return timedelta(minutes=amount)
+            return timedelta(seconds=amount)
+        # Plain numeric string
+        try:
+            return timedelta(seconds=float(text))
+        except ValueError:
+            pass
+    raise ValueError(
+        f"Cannot parse servertimeout value: {value!r}. "
+        "Use a timedelta, 'HH:MM:SS', 'Xm', 'Xs', 'Xh', or numeric seconds."
+    )
+
+
 def _crp(
     action: str, is_destructive: bool, ignore_readonly: bool, client_request_properties: dict[str, Any] | None = None
 ) -> ClientRequestProperties:
@@ -131,16 +183,16 @@ def _crp(
 
     # Set global timeout if configured
     if CONFIG.timeout_seconds is not None:
-        # Convert seconds to timespan format (HH:MM:SS)
-        hours, remainder = divmod(CONFIG.timeout_seconds, 3600)
-        minutes, seconds = divmod(remainder, 60)
-        timeout_str = f"{hours:02d}:{minutes:02d}:{seconds:02d}"
-        crp.set_option("servertimeout", timeout_str)
+        crp.set_option("servertimeout", timedelta(seconds=CONFIG.timeout_seconds))
 
     # Apply any additional client request properties provided by the user
     # User properties can override global settings
     if client_request_properties:
         for key, value in client_request_properties.items():
+            # The Azure Kusto SDK expects servertimeout as a timedelta object —
+            # it adds client_server_delta (timedelta) to it in client_base.py.
+            if key == ClientRequestProperties.request_timeout_option_name:
+                value = _parse_timespan_to_timedelta(value)
             crp.set_option(key, value)
 
     return crp

--- a/fabric_rti_mcp/services/kusto/kusto_service.py
+++ b/fabric_rti_mcp/services/kusto/kusto_service.py
@@ -148,10 +148,7 @@ def _parse_timespan_to_timedelta(value: Any) -> timedelta:
                 minutes=int(match.group(2)),
                 seconds=int(match.group(3)),
             )
-    raise ValueError(
-        f"Cannot parse servertimeout value: {value!r}. "
-        "Use a timedelta, 'HH:MM:SS', or numeric seconds."
-    )
+    raise ValueError(f"Cannot parse servertimeout value: {value!r}. Use a timedelta, 'HH:MM:SS', or numeric seconds.")
 
 
 def _crp(

--- a/tests/unit/kusto/test_global_timeout.py
+++ b/tests/unit/kusto/test_global_timeout.py
@@ -1,6 +1,7 @@
 """Test global timeout configuration for Kusto tools."""
 
 import os
+from datetime import timedelta
 from unittest.mock import Mock, patch
 
 from azure.kusto.data import ClientRequestProperties
@@ -32,8 +33,7 @@ def test_config_no_timeout_env() -> None:
 
 @patch("fabric_rti_mcp.services.kusto.kusto_service.get_kusto_connection")
 def test_global_timeout_applied_to_query(mock_get_connection: Mock) -> None:
-    """Test that global timeout is applied to Kusto queries."""
-    # Mock connection
+    """Test that global timeout is applied to Kusto queries as timedelta."""
     mock_connection = Mock()
     mock_connection.default_database = "TestDB"
     mock_client = Mock()
@@ -43,28 +43,20 @@ def test_global_timeout_applied_to_query(mock_get_connection: Mock) -> None:
     mock_connection.query_client = mock_client
     mock_get_connection.return_value = mock_connection
 
-    # Mock the kusto config with timeout
     with patch("fabric_rti_mcp.services.kusto.kusto_service.CONFIG") as mock_config:
         mock_config.timeout_seconds = 600
         kusto_query("TestQuery", "https://test.kusto.windows.net")
 
-    # Verify that execute was called with ClientRequestProperties
     mock_client.execute.assert_called_once()
-    call_args = mock_client.execute.call_args
-    crp = call_args[0][2]  # Third argument should be ClientRequestProperties
+    crp = mock_client.execute.call_args[0][2]
 
     assert isinstance(crp, ClientRequestProperties)
-    # The timeout should be set as a timedelta (the Azure Kusto SDK requires this)
-    # 600 seconds = 10 minutes
-    from datetime import timedelta
-
     assert crp._options.get("servertimeout") == timedelta(seconds=600)
 
 
 @patch("fabric_rti_mcp.services.kusto.kusto_service.get_kusto_connection")
 def test_no_timeout_when_not_configured(mock_get_connection: Mock) -> None:
     """Test that no timeout is set when not configured."""
-    # Mock connection
     mock_connection = Mock()
     mock_connection.default_database = "TestDB"
     mock_client = Mock()
@@ -74,18 +66,12 @@ def test_no_timeout_when_not_configured(mock_get_connection: Mock) -> None:
     mock_connection.query_client = mock_client
     mock_get_connection.return_value = mock_connection
 
-    # Mock format_results_as_json to return expected result
-
-    # Mock the kusto config without timeout
     with patch("fabric_rti_mcp.services.kusto.kusto_service.CONFIG") as mock_config:
         mock_config.timeout_seconds = None
         kusto_query("TestQuery", "https://test.kusto.windows.net")
 
-    # Verify that execute was called with ClientRequestProperties
     mock_client.execute.assert_called_once()
-    call_args = mock_client.execute.call_args
-    crp = call_args[0][2]  # Third argument should be ClientRequestProperties
+    crp = mock_client.execute.call_args[0][2]
 
     assert isinstance(crp, ClientRequestProperties)
-    # No timeout should be set
     assert "servertimeout" not in crp._options

--- a/tests/unit/kusto/test_global_timeout.py
+++ b/tests/unit/kusto/test_global_timeout.py
@@ -54,10 +54,11 @@ def test_global_timeout_applied_to_query(mock_get_connection: Mock) -> None:
     crp = call_args[0][2]  # Third argument should be ClientRequestProperties
 
     assert isinstance(crp, ClientRequestProperties)
-    # The timeout should be set as server timeout option in HH:MM:SS format
-    # 600 seconds = 10 minutes = 00:10:00
-    expected_timeout = "00:10:00"
-    assert crp._options.get("servertimeout") == expected_timeout
+    # The timeout should be set as a timedelta (the Azure Kusto SDK requires this)
+    # 600 seconds = 10 minutes
+    from datetime import timedelta
+
+    assert crp._options.get("servertimeout") == timedelta(seconds=600)
 
 
 @patch("fabric_rti_mcp.services.kusto.kusto_service.get_kusto_connection")

--- a/tests/unit/kusto/test_servertimeout_conversion.py
+++ b/tests/unit/kusto/test_servertimeout_conversion.py
@@ -1,0 +1,156 @@
+"""Tests for servertimeout timedelta conversion in client_request_properties."""
+
+from datetime import timedelta
+from unittest.mock import Mock, patch
+
+import pytest
+from azure.kusto.data import ClientRequestProperties
+
+from fabric_rti_mcp.services.kusto.kusto_service import (
+    _parse_timespan_to_timedelta,
+    kusto_query,
+)
+
+
+class TestParseTimespanToTimedelta:
+    """Tests for the _parse_timespan_to_timedelta helper."""
+
+    def test_timedelta_passthrough(self) -> None:
+        td = timedelta(minutes=3)
+        assert _parse_timespan_to_timedelta(td) == td
+
+    def test_int_seconds(self) -> None:
+        assert _parse_timespan_to_timedelta(180) == timedelta(seconds=180)
+
+    def test_float_seconds(self) -> None:
+        assert _parse_timespan_to_timedelta(90.5) == timedelta(seconds=90.5)
+
+    def test_hh_mm_ss_format(self) -> None:
+        assert _parse_timespan_to_timedelta("00:03:00") == timedelta(minutes=3)
+
+    def test_h_mm_ss_format(self) -> None:
+        assert _parse_timespan_to_timedelta("1:30:00") == timedelta(hours=1, minutes=30)
+
+    def test_shorthand_minutes(self) -> None:
+        assert _parse_timespan_to_timedelta("3m") == timedelta(minutes=3)
+
+    def test_shorthand_seconds(self) -> None:
+        assert _parse_timespan_to_timedelta("180s") == timedelta(seconds=180)
+
+    def test_shorthand_hours(self) -> None:
+        assert _parse_timespan_to_timedelta("1h") == timedelta(hours=1)
+
+    def test_shorthand_case_insensitive(self) -> None:
+        assert _parse_timespan_to_timedelta("3M") == timedelta(minutes=3)
+
+    def test_numeric_string(self) -> None:
+        assert _parse_timespan_to_timedelta("180") == timedelta(seconds=180)
+
+    def test_whitespace_stripped(self) -> None:
+        assert _parse_timespan_to_timedelta("  00:03:00  ") == timedelta(minutes=3)
+
+    def test_invalid_string_raises(self) -> None:
+        with pytest.raises(ValueError, match="Cannot parse servertimeout"):
+            _parse_timespan_to_timedelta("invalid")
+
+    def test_none_raises(self) -> None:
+        with pytest.raises((ValueError, TypeError)):
+            _parse_timespan_to_timedelta(None)  # type: ignore
+
+
+class TestCrpServertimeoutConversion:
+    """Tests that servertimeout in client_request_properties is converted to timedelta."""
+
+    @patch("fabric_rti_mcp.services.kusto.kusto_service.get_kusto_connection")
+    def test_string_servertimeout_converted(self, mock_get_connection: Mock) -> None:
+        """Passing servertimeout as a string should not crash — it should be converted to timedelta."""
+        mock_connection = Mock()
+        mock_connection.default_database = "TestDB"
+        mock_client = Mock()
+        mock_result = Mock()
+        mock_result.primary_results = None
+        mock_client.execute.return_value = mock_result
+        mock_connection.query_client = mock_client
+        mock_get_connection.return_value = mock_connection
+
+        with patch("fabric_rti_mcp.services.kusto.kusto_service.CONFIG") as mock_config:
+            mock_config.timeout_seconds = None
+            kusto_query(
+                "TestQuery",
+                "https://test.kusto.windows.net",
+                client_request_properties={"servertimeout": "00:03:00"},
+            )
+
+        crp = mock_client.execute.call_args[0][2]
+        assert isinstance(crp, ClientRequestProperties)
+        assert isinstance(crp._options["servertimeout"], timedelta)
+        assert crp._options["servertimeout"] == timedelta(minutes=3)
+
+    @patch("fabric_rti_mcp.services.kusto.kusto_service.get_kusto_connection")
+    def test_shorthand_servertimeout_converted(self, mock_get_connection: Mock) -> None:
+        """Shorthand format like '3m' should also work."""
+        mock_connection = Mock()
+        mock_connection.default_database = "TestDB"
+        mock_client = Mock()
+        mock_result = Mock()
+        mock_result.primary_results = None
+        mock_client.execute.return_value = mock_result
+        mock_connection.query_client = mock_client
+        mock_get_connection.return_value = mock_connection
+
+        with patch("fabric_rti_mcp.services.kusto.kusto_service.CONFIG") as mock_config:
+            mock_config.timeout_seconds = None
+            kusto_query(
+                "TestQuery",
+                "https://test.kusto.windows.net",
+                client_request_properties={"servertimeout": "3m"},
+            )
+
+        crp = mock_client.execute.call_args[0][2]
+        assert crp._options["servertimeout"] == timedelta(minutes=3)
+
+    @patch("fabric_rti_mcp.services.kusto.kusto_service.get_kusto_connection")
+    def test_numeric_servertimeout_converted(self, mock_get_connection: Mock) -> None:
+        """Numeric seconds should also work."""
+        mock_connection = Mock()
+        mock_connection.default_database = "TestDB"
+        mock_client = Mock()
+        mock_result = Mock()
+        mock_result.primary_results = None
+        mock_client.execute.return_value = mock_result
+        mock_connection.query_client = mock_client
+        mock_get_connection.return_value = mock_connection
+
+        with patch("fabric_rti_mcp.services.kusto.kusto_service.CONFIG") as mock_config:
+            mock_config.timeout_seconds = None
+            kusto_query(
+                "TestQuery",
+                "https://test.kusto.windows.net",
+                client_request_properties={"servertimeout": 180},
+            )
+
+        crp = mock_client.execute.call_args[0][2]
+        assert crp._options["servertimeout"] == timedelta(seconds=180)
+
+    @patch("fabric_rti_mcp.services.kusto.kusto_service.get_kusto_connection")
+    def test_non_timeout_properties_unchanged(self, mock_get_connection: Mock) -> None:
+        """Other properties should pass through without conversion."""
+        mock_connection = Mock()
+        mock_connection.default_database = "TestDB"
+        mock_client = Mock()
+        mock_result = Mock()
+        mock_result.primary_results = None
+        mock_client.execute.return_value = mock_result
+        mock_connection.query_client = mock_client
+        mock_get_connection.return_value = mock_connection
+
+        with patch("fabric_rti_mcp.services.kusto.kusto_service.CONFIG") as mock_config:
+            mock_config.timeout_seconds = None
+            kusto_query(
+                "TestQuery",
+                "https://test.kusto.windows.net",
+                client_request_properties={"truncationmaxsize": 51200},
+            )
+
+        crp = mock_client.execute.call_args[0][2]
+        assert crp._options["truncationmaxsize"] == 51200

--- a/tests/unit/kusto/test_servertimeout_conversion.py
+++ b/tests/unit/kusto/test_servertimeout_conversion.py
@@ -1,4 +1,4 @@
-"""Tests for servertimeout timedelta conversion in client_request_properties."""
+"""Test servertimeout conversion in client_request_properties."""
 
 from datetime import timedelta
 from unittest.mock import Mock, patch
@@ -6,151 +6,51 @@ from unittest.mock import Mock, patch
 import pytest
 from azure.kusto.data import ClientRequestProperties
 
-from fabric_rti_mcp.services.kusto.kusto_service import (
-    _parse_timespan_to_timedelta,
-    kusto_query,
-)
+from fabric_rti_mcp.services.kusto.kusto_service import _parse_timespan_to_timedelta, kusto_query
 
 
-class TestParseTimespanToTimedelta:
-    """Tests for the _parse_timespan_to_timedelta helper."""
-
-    def test_timedelta_passthrough(self) -> None:
-        td = timedelta(minutes=3)
-        assert _parse_timespan_to_timedelta(td) == td
-
-    def test_int_seconds(self) -> None:
-        assert _parse_timespan_to_timedelta(180) == timedelta(seconds=180)
-
-    def test_float_seconds(self) -> None:
-        assert _parse_timespan_to_timedelta(90.5) == timedelta(seconds=90.5)
-
-    def test_hh_mm_ss_format(self) -> None:
-        assert _parse_timespan_to_timedelta("00:03:00") == timedelta(minutes=3)
-
-    def test_h_mm_ss_format(self) -> None:
-        assert _parse_timespan_to_timedelta("1:30:00") == timedelta(hours=1, minutes=30)
-
-    def test_shorthand_minutes(self) -> None:
-        assert _parse_timespan_to_timedelta("3m") == timedelta(minutes=3)
-
-    def test_shorthand_seconds(self) -> None:
-        assert _parse_timespan_to_timedelta("180s") == timedelta(seconds=180)
-
-    def test_shorthand_hours(self) -> None:
-        assert _parse_timespan_to_timedelta("1h") == timedelta(hours=1)
-
-    def test_shorthand_case_insensitive(self) -> None:
-        assert _parse_timespan_to_timedelta("3M") == timedelta(minutes=3)
-
-    def test_numeric_string(self) -> None:
-        assert _parse_timespan_to_timedelta("180") == timedelta(seconds=180)
-
-    def test_whitespace_stripped(self) -> None:
-        assert _parse_timespan_to_timedelta("  00:03:00  ") == timedelta(minutes=3)
-
-    def test_invalid_string_raises(self) -> None:
-        with pytest.raises(ValueError, match="Cannot parse servertimeout"):
-            _parse_timespan_to_timedelta("invalid")
-
-    def test_none_raises(self) -> None:
-        with pytest.raises((ValueError, TypeError)):
-            _parse_timespan_to_timedelta(None)  # type: ignore
+def test_parse_timespan_hh_mm_ss() -> None:
+    """Test that 'HH:MM:SS' string is converted to timedelta."""
+    assert _parse_timespan_to_timedelta("00:03:00") == timedelta(minutes=3)
 
 
-class TestCrpServertimeoutConversion:
-    """Tests that servertimeout in client_request_properties is converted to timedelta."""
+def test_parse_timespan_int_seconds() -> None:
+    """Test that integer seconds are converted to timedelta."""
+    assert _parse_timespan_to_timedelta(180) == timedelta(seconds=180)
 
-    @patch("fabric_rti_mcp.services.kusto.kusto_service.get_kusto_connection")
-    def test_string_servertimeout_converted(self, mock_get_connection: Mock) -> None:
-        """Passing servertimeout as a string should not crash — it should be converted to timedelta."""
-        mock_connection = Mock()
-        mock_connection.default_database = "TestDB"
-        mock_client = Mock()
-        mock_result = Mock()
-        mock_result.primary_results = None
-        mock_client.execute.return_value = mock_result
-        mock_connection.query_client = mock_client
-        mock_get_connection.return_value = mock_connection
 
-        with patch("fabric_rti_mcp.services.kusto.kusto_service.CONFIG") as mock_config:
-            mock_config.timeout_seconds = None
-            kusto_query(
-                "TestQuery",
-                "https://test.kusto.windows.net",
-                client_request_properties={"servertimeout": "00:03:00"},
-            )
+def test_parse_timespan_timedelta_passthrough() -> None:
+    """Test that timedelta values pass through unchanged."""
+    td = timedelta(minutes=3)
+    assert _parse_timespan_to_timedelta(td) == td
 
-        crp = mock_client.execute.call_args[0][2]
-        assert isinstance(crp, ClientRequestProperties)
-        assert isinstance(crp._options["servertimeout"], timedelta)
-        assert crp._options["servertimeout"] == timedelta(minutes=3)
 
-    @patch("fabric_rti_mcp.services.kusto.kusto_service.get_kusto_connection")
-    def test_shorthand_servertimeout_converted(self, mock_get_connection: Mock) -> None:
-        """Shorthand format like '3m' should also work."""
-        mock_connection = Mock()
-        mock_connection.default_database = "TestDB"
-        mock_client = Mock()
-        mock_result = Mock()
-        mock_result.primary_results = None
-        mock_client.execute.return_value = mock_result
-        mock_connection.query_client = mock_client
-        mock_get_connection.return_value = mock_connection
+def test_parse_timespan_invalid_raises() -> None:
+    """Test that unsupported formats raise ValueError."""
+    with pytest.raises(ValueError, match="Cannot parse servertimeout"):
+        _parse_timespan_to_timedelta("3m")
 
-        with patch("fabric_rti_mcp.services.kusto.kusto_service.CONFIG") as mock_config:
-            mock_config.timeout_seconds = None
-            kusto_query(
-                "TestQuery",
-                "https://test.kusto.windows.net",
-                client_request_properties={"servertimeout": "3m"},
-            )
 
-        crp = mock_client.execute.call_args[0][2]
-        assert crp._options["servertimeout"] == timedelta(minutes=3)
+@patch("fabric_rti_mcp.services.kusto.kusto_service.get_kusto_connection")
+def test_servertimeout_string_converted_end_to_end(mock_get_connection: Mock) -> None:
+    """Test that servertimeout string in client_request_properties is converted to timedelta through kusto_query."""
+    mock_connection = Mock()
+    mock_connection.default_database = "TestDB"
+    mock_client = Mock()
+    mock_result = Mock()
+    mock_result.primary_results = None
+    mock_client.execute.return_value = mock_result
+    mock_connection.query_client = mock_client
+    mock_get_connection.return_value = mock_connection
 
-    @patch("fabric_rti_mcp.services.kusto.kusto_service.get_kusto_connection")
-    def test_numeric_servertimeout_converted(self, mock_get_connection: Mock) -> None:
-        """Numeric seconds should also work."""
-        mock_connection = Mock()
-        mock_connection.default_database = "TestDB"
-        mock_client = Mock()
-        mock_result = Mock()
-        mock_result.primary_results = None
-        mock_client.execute.return_value = mock_result
-        mock_connection.query_client = mock_client
-        mock_get_connection.return_value = mock_connection
+    with patch("fabric_rti_mcp.services.kusto.kusto_service.CONFIG") as mock_config:
+        mock_config.timeout_seconds = None
+        kusto_query(
+            "TestQuery",
+            "https://test.kusto.windows.net",
+            client_request_properties={"servertimeout": "00:03:00"},
+        )
 
-        with patch("fabric_rti_mcp.services.kusto.kusto_service.CONFIG") as mock_config:
-            mock_config.timeout_seconds = None
-            kusto_query(
-                "TestQuery",
-                "https://test.kusto.windows.net",
-                client_request_properties={"servertimeout": 180},
-            )
-
-        crp = mock_client.execute.call_args[0][2]
-        assert crp._options["servertimeout"] == timedelta(seconds=180)
-
-    @patch("fabric_rti_mcp.services.kusto.kusto_service.get_kusto_connection")
-    def test_non_timeout_properties_unchanged(self, mock_get_connection: Mock) -> None:
-        """Other properties should pass through without conversion."""
-        mock_connection = Mock()
-        mock_connection.default_database = "TestDB"
-        mock_client = Mock()
-        mock_result = Mock()
-        mock_result.primary_results = None
-        mock_client.execute.return_value = mock_result
-        mock_connection.query_client = mock_client
-        mock_get_connection.return_value = mock_connection
-
-        with patch("fabric_rti_mcp.services.kusto.kusto_service.CONFIG") as mock_config:
-            mock_config.timeout_seconds = None
-            kusto_query(
-                "TestQuery",
-                "https://test.kusto.windows.net",
-                client_request_properties={"truncationmaxsize": 51200},
-            )
-
-        crp = mock_client.execute.call_args[0][2]
-        assert crp._options["truncationmaxsize"] == 51200
+    crp = mock_client.execute.call_args[0][2]
+    assert isinstance(crp, ClientRequestProperties)
+    assert crp._options["servertimeout"] == timedelta(minutes=3)


### PR DESCRIPTION
Fixes #137

## Problem

Passing `servertimeout` via `client_request_properties` on any Kusto tool (e.g. `kusto_query`) crashes with:

```
TypeError: can only concatenate str (not "datetime.timedelta") to str
```

### Reproduction

```python
kusto_query(
    query="MyTable | take 1",
    cluster_uri="https://mycluster.kusto.windows.net",
    client_request_properties={"servertimeout": "00:03:00"}
)
```

## Root Cause

In `_crp()`, user-provided properties are passed to `crp.set_option()` as-is (line ~142). But the Azure Kusto SDK (`azure-kusto-data`, `client_base.py` line ~253) retrieves `servertimeout` and performs `timeout + client_server_delta` — which requires a `timedelta`, not a string.

There is also a **latent bug** in the global timeout path (lines 133-138): `CONFIG.timeout_seconds` is converted to a string `"HH:MM:SS"` format before `set_option()` — this would crash the same way if the CRP flows through the SDK's timeout arithmetic.

## Fix

- Added `_parse_timespan_to_timedelta()` helper that converts servertimeout values to `timedelta`. Accepted formats: `"HH:MM:SS"` string, `int`/`float` seconds, and `timedelta` passthrough.
- Pre-compiled regex pattern at module level for efficiency.
- Applied conversion in `_crp()` when key matches `ClientRequestProperties.request_timeout_option_name`.
- Fixed global `CONFIG.timeout_seconds` path to use `timedelta(seconds=...)` directly.
- Updated existing `test_global_timeout_applied_to_query` to expect `timedelta` instead of string.
- Added 5 new tests for the conversion logic and end-to-end CRP integration.

## Testing

All 62 unit tests pass (`pytest tests/unit/`), plus live tests against `help.kusto.windows.net`.
