### PR TITLE
Add KQL Copilot Skill and fix README issues

### DIFF
--- a/.github/skills/kql/SKILL.md
+++ b/.github/skills/kql/SKILL.md
@@ -1,0 +1,470 @@
+---
+name: kql
+description: "KQL language expertise for writing correct, efficient Kusto queries using the Fabric RTI MCP tools. Covers syntax gotchas, join patterns, dynamic types, datetime pitfalls, regex patterns, serialization, memory management, result-size discipline, and advanced functions (geo, vector, graph). USE THIS SKILL whenever writing, debugging, or reviewing KQL queries — even simple ones — because the gotchas section prevents the most common errors that waste tool calls and cause expensive retry cascades. Trigger on: KQL, Kusto, ADX, Azure Data Explorer, Fabric Eventhouse, log analysis, data exploration, time series, anomaly detection, summarize, where clause, join, extend, project, let statement, parse operator, extract function, any mention of pipe-forward query syntax."
+---
+
+# KQL Mastery
+
+## 1. Running KQL with Fabric RTI MCP
+
+Fabric RTI MCP exposes Kusto functionality as MCP tools. Authentication is handled transparently using Azure Identity.
+
+### Available tools
+
+| Tool | Purpose |
+|------|---------|
+| `kusto_query` | Execute a KQL query on a database |
+| `kusto_command` | Execute a management command (`.show`, `.create`, etc.) |
+| `kusto_list_entities` | List databases, tables, external tables, materialized views, functions, graphs |
+| `kusto_describe_database` | Get schema for all entities in a database |
+| `kusto_describe_database_entity` | Get schema for a specific entity (table, function, etc.) |
+| `kusto_sample_entity` | Get sample data from a table or other entity |
+| `kusto_graph_query` | Execute a graph query using snapshots or transient graphs |
+| `kusto_ingest_inline_into_table` | Ingest inline CSV data into a table |
+| `kusto_known_services` | List configured Kusto services |
+| `kusto_get_shots` | Retrieve semantically similar shots from a shots table |
+| `kusto_deeplink_from_query` | Build a deeplink URL to open a query in the web explorer |
+
+### Query vs management commands
+
+KQL has two execution planes, each with its own MCP tool:
+
+| Plane | Tool | Starts with | Examples |
+|-------|------|-------------|----------|
+| **Query** | `kusto_query` | Table name, `let`, `print`, `datatable` | `StormEvents \| where State == "TEXAS"` |
+| **Management** | `kusto_command` | `.show`, `.create`, `.set`, `.drop`, `.alter` | `.show tables`, `.show table T schema` |
+
+### Basic usage
+
+```
+# Query plane — use kusto_query
+kusto_query(
+    cluster_uri="https://help.kusto.windows.net",
+    database="Samples",
+    query="StormEvents | summarize count() by EventType | top 5 by count_ desc"
+)
+
+# Management plane — use kusto_command
+kusto_command(
+    cluster_uri="https://help.kusto.windows.net",
+    database="Samples",
+    command=".show tables"
+)
+
+# Schema exploration — use kusto_describe_database or kusto_describe_database_entity
+kusto_describe_database(
+    cluster_uri="https://help.kusto.windows.net",
+    database="Samples"
+)
+
+# Sample data — use kusto_sample_entity
+kusto_sample_entity(
+    cluster_uri="https://help.kusto.windows.net",
+    database="Samples",
+    entity_name="StormEvents",
+    entity_type="table",
+    sample_size=5
+)
+
+# Graph queries — use kusto_graph_query
+kusto_graph_query(
+    cluster_uri="https://mycluster.kusto.windows.net",
+    database="MyDB",
+    graph_name="MyGraph",
+    query="| graph-match (node) project labels=labels(node)"
+)
+
+# Deeplinks — use kusto_deeplink_from_query
+kusto_deeplink_from_query(
+    cluster_uri="https://help.kusto.windows.net",
+    database="Samples",
+    query="StormEvents | count"
+)
+```
+
+### Exploration workflow
+
+When encountering a new cluster or database:
+
+1. **List entities**: `kusto_list_entities(cluster_uri, entity_type="tables", database="MyDB")`
+2. **Get schema**: `kusto_describe_database_entity(entity_name="MyTable", entity_type="table", cluster_uri=..., database=...)`
+3. **Sample data**: `kusto_sample_entity(entity_name="MyTable", entity_type="table", cluster_uri=..., sample_size=5)`
+4. **Count rows**: `kusto_query(query="MyTable | count", cluster_uri=..., database=...)`
+5. **Run analysis**: `kusto_query(query="MyTable | where ... | summarize ...", cluster_uri=..., database=...)`
+
+## 2. Dynamic Type Discipline
+
+KQL's `dynamic` type is flexible but strict in certain contexts. A common mistake is using a dynamic column in `summarize by`, `order by`, or `join on` without casting.
+
+**The rule**: Any time you use a dynamic-typed column in `by`, `on`, or `order by`, wrap it in an explicit cast.
+
+```kql
+// ❌ ERROR: "Summarize group key 'Partners' is of a 'dynamic' type"
+| summarize count() by Partners
+
+// ✅ FIX
+| summarize count() by tostring(Partners)
+```
+
+```kql
+// ❌ ERROR: "order operator: key can't be of dynamic type"
+| order by Area desc
+
+// ✅ FIX
+| order by tostring(Area) desc
+```
+
+```kql
+// ❌ ERROR in join: dynamic join key
+| join kind=inner other on $left.Area == $right.Area
+
+// ✅ FIX — cast both sides
+| extend Area_str = tostring(Area)
+| join kind=inner (other | extend Area_str = tostring(Area)) on Area_str
+```
+
+**Self-correction**: When you see "is of a 'dynamic' type" in an error, add `tostring()`, `tolong()`, or `todouble()`.
+
+## 3. Join Patterns & Pitfalls
+
+KQL joins have constraints that differ from SQL.
+
+### Equality only
+KQL join conditions support **only `==`**. No `<`, `>`, `!=`, or function calls in join predicates.
+
+```kql
+// ❌ ERROR: "Only equality is allowed in this context"
+| join on geo_distance_2points(a.Lat, a.Lon, b.Lat, b.Lon) < 1000
+
+// ✅ WORKAROUND — pre-bucket into spatial cells, then join on cell ID
+| extend cell = geo_point_to_s2cell(Lon, Lat, 8)
+| join kind=inner (other | extend cell = geo_point_to_s2cell(Lon, Lat, 8)) on cell
+```
+
+For range joins, pre-bin values: `| extend bin_val = bin(Value, 100)`, then join on `bin_val`.
+
+### Left/right attribute matching
+Both sides of a join `on` clause must reference **column entities only** — not expressions, not aggregates.
+
+```kql
+// ❌ ERROR: "for each left attribute, right attribute should be selected"
+| join kind=inner other on $left.col1
+
+// ✅ FIX — specify both sides explicitly
+| join kind=inner other on $left.col1 == $right.col1
+```
+
+### Cardinality check before large joins
+**Always** check cardinality before joining tables with >10K rows. A cross-join explosion was the source of the single `E_RUNAWAY_QUERY` error (25K × 195 = potential 4.8M rows).
+
+```kql
+// Before joining, check how many rows each side contributes
+TableA | summarize dcount(JoinKey)  // → 25,000? Too many for an unconstrained join
+TableB | summarize dcount(JoinKey)  // → 195? OK if filtered first
+```
+
+## 4. Regex in KQL
+
+KQL handles regex natively — no need for Python.
+
+### The `extract_all` gotcha
+Unlike Python's `re.findall()`, KQL's `extract_all` **requires capturing groups** in the regex:
+
+```kql
+// ❌ ERROR: "extractall(): argument 2 must be a valid regex with [1..16] matching groups"
+| extend words = extract_all(@"[a-zA-Z]{3,}", Text)
+
+// ✅ FIX — add parentheses around the pattern
+| extend words = extract_all(@"([a-zA-Z]{3,})", Text)
+```
+
+### Regex toolkit — don't fall back to Python
+| Function | Use case | Example |
+|----------|----------|---------|
+| `extract(regex, group, source)` | Single match | `extract(@"User '([^']+)'", 1, Msg)` |
+| `extract_all(regex, source)` | All matches (needs `()`) | `extract_all(@"(\w+)", Text)` |
+| `parse` | Structured extraction | `parse Msg with * "User '" Sender "' sent" *` |
+| `matches regex` | Boolean filter | `where Url matches regex @"^https?://"` |
+| `replace_regex` | Find and replace | `replace_regex(@"\s+", " ", Text)` |
+
+## 5. Serialization Requirements
+
+Window functions need serialized (ordered) input.
+
+```kql
+// ❌ ERROR: "Function 'row_cumsum' cannot be invoked. The row set must be serialized."
+| summarize Online = sum(Direction) by bin(Timestamp, 5m)
+| extend CumulativeOnline = row_cumsum(Online)
+
+// ✅ FIX — add | serialize (or | order by, which implicitly serializes)
+| summarize Online = sum(Direction) by bin(Timestamp, 5m)
+| order by Timestamp asc
+| extend CumulativeOnline = row_cumsum(Online)
+```
+
+Functions requiring serialization: `row_number()`, `row_cumsum()`, `prev()`, `next()`, `row_window_session()`.
+
+## 6. Memory-Safe Query Patterns
+
+The most common memory error. Caused by scanning too much data without pre-filtering.
+
+### The progression of safety
+```
+Safest ──────────────────────────────────────────────── Most dangerous
+| count    | take 10    | where + summarize    | summarize (no filter)    | full scan
+```
+
+### Rules for large tables (>1M rows)
+
+1. **Always start with `| count`** to understand table size
+2. **Always `| where` before `| summarize`** — filter time range, partition key, or category first
+3. **Never `dcount()` on high-cardinality columns** without pre-filtering
+4. **Check join cardinality** before executing (see Section 3)
+5. **Use `materialize()`** for subqueries referenced multiple times
+
+```kql
+// ❌ OUT OF MEMORY — 24M rows, no filter, dcount on every column
+Consumption
+| summarize dcount(Consumed), count() by Timestamp, HouseholdId, MeterType
+| where dcount_Consumed > 1
+
+// ✅ SAFE — filter first, then aggregate
+Consumption
+| where Timestamp between (datetime(2023-04-15) .. datetime(2023-04-16))
+| summarize dcount(Consumed) by HouseholdId, MeterType
+| where dcount_Consumed > 1
+```
+
+### When you see `E_LOW_MEMORY_CONDITION`
+The query touched too much data. Your options:
+- Add `| where` filters (time range, partition key)
+- Reduce the number of `by` columns in `summarize`
+- Break into smaller time windows and union results
+- Use `| sample 10000` for exploratory work instead of full scans
+
+### When you see `E_RUNAWAY_QUERY`
+A join or aggregation produced too many output rows. Check join cardinality — one or both sides is too large.
+
+## 7. Result Size Discipline
+
+Large results slow down analysis. Prevention:
+
+| Query type | Safeguard |
+|-----------|-----------|
+| Exploratory | Always end with `\| take 10` or `\| take 20` |
+| Aggregation | Use `\| top 20 by ...` not unbounded `summarize` |
+| Wide rows (vectors, JSON) | `\| project` only needed columns |
+| `make_list()` / `make_set()` | Avoid on high-cardinality groups (produces huge cells) |
+| Unknown size | Run `\| count` first |
+
+**The vector trap**: Tables with embedding columns (1536-dim float arrays) produce ~30KB per row. Even `| take 20` yields 600KB. Always `| project` away vector columns unless you specifically need them.
+
+**With MCP tools**: Use `kusto_sample_entity` for quick data previews. For deeper exploration, use `kusto_query` with `| take N` or `| top N` to bound results.
+
+## 8. String Comparison Strictness
+
+KQL sometimes requires explicit casts when comparing computed string values — even when both sides are already strings.
+
+```kql
+// ❌ ERROR: "Cannot compare values of types string and string. Try adding explicit casts"
+| where geo_point_to_s2cell(Lon, Lat, 16) == other_cell
+
+// ✅ FIX — wrap both sides in tostring()
+| where tostring(geo_point_to_s2cell(Lon, Lat, 16)) == tostring(other_cell)
+```
+
+This is most common with computed values from `geo_point_to_s2cell()`, `hash()`, and `strcat()` comparisons. When in doubt, cast with `tostring()`.
+
+## 9. Advanced Functions
+
+KQL handles these natively — no need for Python:
+
+### Vector similarity
+```kql
+// Don't export vectors and compute cosine similarity in Python
+let target = toscalar(Vectors | where Word == "test" | project Vec);
+Data | extend sim = series_cosine_similarity(parse_json(VecColumn), target)
+| top 10 by sim desc
+```
+
+### Geo operations
+```kql
+// Point-in-polygon check
+| where geo_point_in_polygon(Longitude, Latitude, dynamic({"type":"Polygon","coordinates":[...]}))
+
+// Distance between two points (meters)
+| extend dist = geo_distance_2points(Lon1, Lat1, Lon2, Lat2)
+
+// Spatial bucketing for joins
+| extend cell = geo_point_to_s2cell(Lon, Lat, 8)
+```
+
+### Graph queries
+
+Use the `kusto_graph_query` MCP tool for graph traversal. It automatically handles graph snapshots when available:
+
+```kql
+// Build and traverse a graph
+graph(Nodes, Edges)
+| graph-match (src)-[e*1..5]->(dst)
+  where src.Name == "start" and dst.IsTarget == true
+  project src.Name, dst.Name, path_length = array_length(e)
+```
+
+### Time series
+```kql
+// Create a time series and detect anomalies
+| make-series count() default=0 on Timestamp step 1h
+| extend anomalies = series_decompose_anomalies(count_)
+```
+
+For detailed examples and patterns, consult `references/advanced-patterns.md`.
+
+## 10. Self-Correction Lookup Table
+
+When you encounter an error, look it up here before retrying:
+
+| Error message contains | Likely cause | Fix |
+|---|---|---|
+| `is of a 'dynamic' type` | Dynamic column in `by`/`on`/`order by` | Wrap in `tostring()`/`tolong()` |
+| `Only equality is allowed` | Range predicate in join condition | Pre-bucket with S2/H3 cells or `bin()` |
+| `extractall(): matching groups` | Missing `()` in regex | Add `()`: `@"(\w+)"` not `@"\w+"` |
+| `row set must be serialized` | Window function on unsorted data | Add `\| serialize` or `\| order by` before it |
+| `Cannot compare values of types string and string` | Computed string comparison | Add `tostring()` on both sides |
+| `Failed to resolve column named 'X'` | Wrong column name or wrong table | Use `kusto_describe_database_entity` to check column names |
+| `E_LOW_MEMORY_CONDITION` | Query touched too much data | Add `\| where` filters, reduce time range, break into steps |
+| `E_RUNAWAY_QUERY` | Join/aggregation produced too many rows | Check cardinality before joining; add pre-filters |
+| `for each left attribute, right attribute` | Join `on` clause incomplete | Use explicit form: `on $left.X == $right.Y` |
+| `needs to be bracketed` | Reserved word used as identifier | Use `['keyword']` syntax |
+| `plugin doesn't exist` | Unavailable plugin on this cluster | Fall back to equivalent function or Python |
+| `Expected string literal in datetime()` | Bare integer in datetime literal | Use `datetime(2024-01-01)` not `datetime(2024)` |
+| `Unexpected token` after `by` | Complex expression in summarize by-clause | `extend` the expression first, then `summarize by` the column |
+| `not recognized` / `unknown operator` | Operator not available on this engine | Check operator support; try equivalent (`order by` = `sort by`) |
+
+## 11. Datetime Pitfalls
+
+Datetime literals are a common source of errors. A wrong literal format can cascade into completely different approaches instead of fixing the small issue.
+
+### Literal format
+```kql
+// ❌ WRONG — bare year is not a valid datetime
+| where StartTime > datetime(2007)
+
+// ✅ RIGHT — always use full date format
+| where StartTime > datetime(2007-01-01)
+```
+
+### Filtering by year, month, or hour
+```kql
+// ❌ WRONG — comparing datetime column to integer
+| where StartTime == 2007
+
+// ✅ RIGHT — use datetime_part() to extract components
+| where datetime_part("year", StartTime) == 2007
+
+// ✅ ALSO RIGHT — use between with datetime range
+| where StartTime between (datetime(2007-01-01) .. datetime(2007-12-31))
+```
+
+### Time bucketing in summarize
+```kql
+// ❌ WRONG — complex expression directly in by-clause can fail in some engines
+| summarize count() by startofmonth(StartTime)
+
+// ✅ SAFER — extend first, then summarize by the computed column
+| extend Month = startofmonth(StartTime)
+| summarize count() by Month
+| order by Month asc
+```
+
+### Useful datetime functions
+| Function | Purpose | Example |
+|----------|---------|---------|
+| `bin(ts, 1h)` | Round to nearest bucket | `bin(Timestamp, 1d)` |
+| `startofmonth(ts)` | First day of month | `startofmonth(Timestamp)` |
+| `datetime_part("hour", ts)` | Extract component | `datetime_part("year", Timestamp)` |
+| `format_datetime(ts, fmt)` | Format as string | `format_datetime(Timestamp, "yyyy-MM")` |
+| `ago(1d)` | Relative time | `where Timestamp > ago(7d)` |
+| `between(a .. b)` | Range filter | `where Timestamp between (datetime(2024-01-01) .. datetime(2024-01-31))` |
+| `todatetime(str)` | Parse string → datetime | `todatetime("2024-01-15T10:30:00Z")` |
+| `totimespan(str)` | Parse string → timespan | `totimespan("01:30:00")` |
+
+## 12. Operator Naming & Equality
+
+KQL has subtle differences from SQL syntax.
+
+### Equality operators
+```kql
+// In where clauses, == is case-sensitive, =~ is case-insensitive
+| where State == "TEXAS"      // exact match
+| where State =~ "texas"      // case-insensitive
+| where State != "TEXAS"      // not equal
+| where State !~ "texas"      // case-insensitive not equal
+
+// In joins, use == only
+| join kind=inner other on $left.Key == $right.Key
+```
+
+### sort vs order
+Both `sort by` and `order by` work identically in KQL — they are aliases. Use whichever you prefer, but be consistent.
+
+### contains vs has
+```kql
+// contains: substring match (slower)
+| where Message contains "error"        // finds "MyErrorHandler" too
+
+// has: term/word match (faster, uses index)
+| where Message has "error"             // matches word boundaries only
+
+// For exact prefix/suffix
+| where Message startswith "Error:"
+| where Message endswith ".log"
+```
+
+## 13. Error Recovery Strategy
+
+When a first KQL query fails, the temptation is to abandon the entire approach and try something completely different. The correct response is almost always to **fix the specific error**, not change strategy.
+
+### The pattern to avoid
+```
+Query 1: extract(@"pattern", 1, col)  → Parse error
+Query 2: todynamic(col)               → Different error  
+Query 3: parse_json(col)              → Another error
+Query 4: Python script                → Works but 10x tokens
+```
+
+### The correct pattern
+```
+Query 1: extract(@"pattern", 1, col)  → Parse error (bad escaping)
+Query 2: extract(@"pattern", 1, col)  → Fix the specific escaping issue → Success
+```
+
+**Rules for error recovery:**
+1. Read the error message carefully — it almost always tells you exactly what's wrong
+2. Fix the **specific** syntax/escaping issue, don't switch approaches
+3. Use the self-correction table (Section 10) to map errors to fixes
+4. Only switch approaches after 2 failed fixes of the same query
+5. The `parse` operator is often simpler than `extract()` for structured text:
+
+```kql
+// Instead of complex regex:
+// extract(@"User '([^']+)' sent (\d+) bytes", 1, Message)
+
+// Use parse for structured extraction:
+| parse Message with * "User '" Username "' sent " ByteCount " bytes" *
+```
+
+## 14. Query Writing Checklist
+
+Before running any KQL query, mentally check:
+
+1. **Pre-filtered?** Large tables have a `| where` before any `| summarize`
+2. **Result bounded?** Exploratory queries end with `| take N` or `| top N`
+3. **Dynamic columns cast?** Any dynamic column in `by`/`on`/`order by` is wrapped
+4. **Regex has groups?** `extract_all` patterns have `()` around what you want to capture
+5. **Join cardinality safe?** Both sides checked with `dcount()` before joining
+6. **Needed columns only?** Wide tables get `| project` to drop unneeded columns
+7. **Datetime literals valid?** Using `datetime(2024-01-01)` not `datetime(2024)` or bare integers
+8. **Complex by-expressions?** Use `| extend` first, then `| summarize by` the computed column
+9. **Error recovery plan?** If a query fails, fix the specific error — don't change strategy
+10. **Right tool?** Use `kusto_query` for queries, `kusto_command` for management commands, `kusto_sample_entity` for quick previews

--- a/.github/skills/kql/references/advanced-patterns.md
+++ b/.github/skills/kql/references/advanced-patterns.md
@@ -1,0 +1,363 @@
+# Advanced KQL Patterns
+
+Reference for specialized KQL features: graph queries, vector similarity, geospatial operations, time series, and external data. Consult this when a task requires these capabilities.
+
+## Table of Contents
+
+1. [Graph Queries](#1-graph-queries)
+2. [Vector Similarity](#2-vector-similarity)
+3. [Geospatial Operations](#3-geospatial-operations)
+4. [Time Series Analysis](#4-time-series-analysis)
+5. [External Data](#5-external-data)
+6. [Stored Functions](#6-stored-functions)
+7. [Materialized Views & Caching](#7-materialized-views--caching)
+
+---
+
+## 1. Graph Queries
+
+KQL's graph model requires building a graph from node/edge tables, then traversing with `graph-match`.
+
+### Building a graph
+
+```kql
+// Define nodes and edges
+let nodes = YaccApplications | project NodeId = AppId, AppName, HostingIp;
+let edges = YaccConnections | project SourceId = SourceAppId, TargetId = TargetAppId, Protocol, Port;
+
+// Build and query
+graph(nodes, edges)
+| graph-match (src)-[e]->(dst)
+  where src.AppName == "Gateway"
+  project src.AppName, dst.AppName, e.Protocol
+```
+
+### Variable-length traversal
+
+```kql
+// Find all paths up to 5 hops from a start node
+graph(nodes, edges)
+| graph-match (start)-[path*1..5]->(target)
+  where start.AppName == "Frontend"
+  project start.AppName, target.AppName, hops = array_length(path)
+```
+
+### Pre-filtering edges (the key pattern)
+
+Important: **filter edges BEFORE building the graph**, not during traversal. Edge properties are not accessible on variable-length paths during `graph-match`.
+
+```kql
+// ❌ WRONG — can't access properties on variable-length edge
+graph-match (src)-[path*1..3]->(dst)
+  where path.IsVulnerable == true
+
+// ✅ RIGHT — pre-filter edges
+let vulnerable_edges = Edges | where IsVulnerable == true;
+graph(Nodes, vulnerable_edges)
+| graph-match (src)-[path*1..3]->(dst)
+  project src.Name, dst.Name
+```
+
+### Persistent graph snapshots
+
+For repeated traversals, create a snapshot:
+
+```kql
+// Create once (management command)
+.create graph-snapshot MyGraph
+  <| graph(nodes, edges)
+
+// Query repeatedly
+graph("MyGraph")
+| graph-match (src)-[e]->(dst)
+  where src.Type == "Server"
+  project src.Name, dst.Name
+```
+
+### graph-to-table for post-processing
+
+```kql
+graph(nodes, edges)
+| graph-match (src)-[e]->(dst)
+  project src.Name, dst.Name, e.Weight
+| graph-to-table
+| summarize TotalWeight = sum(Weight) by src_Name
+| top 10 by TotalWeight desc
+```
+
+---
+
+## 2. Vector Similarity
+
+KQL has native vector operations — **don't export to Python** for cosine similarity.
+
+### series_cosine_similarity
+
+The most common vector operation.
+
+```kql
+// Find the most similar items to a target vector
+let target_vec = toscalar(
+    Embeddings | where Word == "test" | project Vec
+);
+Embeddings
+| extend similarity = series_cosine_similarity(parse_json(Vec), target_vec)
+| top 10 by similarity desc
+```
+
+### Combining vectors
+
+```kql
+// Weighted vector combination (e.g., word1 * 0.5 + word2 * 0.3 + word3 * 0.2)
+let v1 = toscalar(Vecs | where Word == "hello" | project Vec);
+let v2 = toscalar(Vecs | where Word == "world" | project Vec);
+let v3 = toscalar(Vecs | where Word == "test" | project Vec);
+let combined = series_add(
+    series_add(
+        series_multiply(v1, repeat(0.5, array_length(v1))),
+        series_multiply(v2, repeat(0.3, array_length(v2)))
+    ),
+    series_multiply(v3, repeat(0.2, array_length(v3)))
+);
+```
+
+### Performance consideration
+
+Pairwise cosine similarity on 1536-dim vectors is expensive (~20s for large tables). Strategies:
+
+1. **Pre-filter** — narrow candidates before computing similarity
+2. **Round-and-join** — bucket vector dimensions to integers, join on buckets for approximate matching
+3. **Project away vectors** — never include vector columns in results unless needed
+
+```kql
+// Round-and-join for approximate nearest neighbor
+let target_rounded = toscalar(
+    Vecs | where Word == "test"
+    | project r = array_sort_asc(series_multiply(Vec, repeat(100, array_length(Vec))))
+);
+Vecs
+| extend rounded = array_sort_asc(series_multiply(Vec, repeat(100, array_length(Vec))))
+| where rounded[0] between (target_rounded[0]-10 .. target_rounded[0]+10)
+| extend sim = series_cosine_similarity(Vec, toscalar(Vecs | where Word == "test" | project Vec))
+| top 10 by sim desc
+```
+
+### Other series functions
+
+| Function | Purpose |
+|----------|---------|
+| `series_cosine_similarity(a, b)` | Cosine similarity between two vectors |
+| `series_pearson_correlation(a, b)` | Pearson correlation |
+| `series_dot_product(a, b)` | Dot product |
+| `series_add(a, b)` | Element-wise addition |
+| `series_multiply(a, b)` | Element-wise multiplication |
+| `series_subtract(a, b)` | Element-wise subtraction |
+| `series_magnitude(a)` | L2 norm |
+
+---
+
+## 3. Geospatial Operations
+
+### Point-in-polygon
+
+```kql
+// Check if a point is inside a polygon
+| where geo_point_in_polygon(Longitude, Latitude,
+    dynamic({"type":"Polygon","coordinates":[[[lon1,lat1],[lon2,lat2],...,[lon1,lat1]]]}))
+```
+
+Note: `geo_point_in_polygon` is a **scalar function**, not a plugin. It works on free clusters. Don't try to `evaluate` it as a plugin — use it directly in `| where` or `| extend`.
+
+### Distance calculations
+
+```kql
+// Distance between two points (returns meters)
+| extend distance_m = geo_distance_2points(Lon1, Lat1, Lon2, Lat2)
+
+// Filter by distance
+| where geo_distance_2points(Lon, Lat, -122.33, 47.61) < 5000  // within 5km of Seattle
+```
+
+### Spatial bucketing for joins
+
+KQL joins are equality-only, so spatial proximity joins need pre-bucketing:
+
+```kql
+// S2 cells (Google's spatial index)
+| extend cell = geo_point_to_s2cell(Longitude, Latitude, 8)  // level 8 ≈ 30km²
+
+// H3 cells (Uber's spatial index)
+| extend cell = geo_point_to_h3cell(Longitude, Latitude, 5)  // resolution 5 ≈ 253km²
+
+// Then join on cell IDs
+TableA
+| extend cell = geo_point_to_s2cell(Lon, Lat, 10)
+| join kind=inner (TableB | extend cell = geo_point_to_s2cell(Lon, Lat, 10)) on cell
+```
+
+### IP geolocation
+
+```kql
+// Lookup IP addresses against a geo table
+| evaluate ipv4_lookup(IpGeoTable, ClientIP, IpRange)
+
+// Check if IP is in a range
+| where ipv4_is_in_range(ClientIP, "10.0.0.0/8")
+
+// Compare two IPs for subnet membership
+| where ipv4_is_in_any_range(ClientIP, dynamic(["10.0.0.0/8", "172.16.0.0/12"]))
+```
+
+---
+
+## 4. Time Series Analysis
+
+### Creating time series
+
+```kql
+// Basic time series
+Events
+| make-series count() default=0 on Timestamp step 1h
+| render timechart
+
+// Multi-series (one per category)
+Events
+| make-series count() default=0 on Timestamp step 1h by Category
+```
+
+### Anomaly detection
+
+```kql
+// Decompose and find anomalies
+Events
+| make-series count() default=0 on Timestamp step 1h
+| extend (anomalies, score, baseline) = series_decompose_anomalies(count_)
+| mv-expand Timestamp, count_, anomalies, score, baseline
+| where anomalies != 0
+```
+
+### Period detection
+
+```kql
+// Find periodic patterns
+Events
+| make-series count() default=0 on Timestamp step 1m
+| extend (periods, scores) = series_periods_detect(count_, 4.0, 1440.0, 2)
+```
+
+### Sessionization
+
+```kql
+// Group events into sessions with 30-minute gap
+Events
+| order by UserId, Timestamp asc
+| extend SessionId = row_window_session(Timestamp, 30m, 24h, UserId != prev(UserId))
+```
+
+### Sliding window statistics
+
+```kql
+// Rolling average over 7 days
+| make-series val=avg(Value) on Timestamp step 1d
+| extend rolling_avg = series_fir(val, repeat(1.0/7, 7), false)
+```
+
+---
+
+## 5. External Data
+
+Load external files directly into KQL without ingestion:
+
+```kql
+// CSV from blob storage
+let external_csv = external_data(col1:string, col2:long)
+  [h@'https://storage.blob.core.windows.net/container/file.csv']
+  with (ignoreFirstRecord=true);
+external_csv | where col2 > 100
+```
+
+```kql
+// Gzipped CSV
+let primes = external_data(prime:long)
+  [h@'https://yourstorage.blob.core.windows.net/prime-numbers/prime-numbers.csv.gz']
+  with (ignoreFirstRecord=true);
+primes | where prime < 100000000 | summarize max(prime)
+```
+
+**Limitations**: `external_data` handles tabular formats (CSV, TSV, JSON lines). For non-tabular content (images, PDFs, JavaScript), use the browser or Python.
+
+---
+
+## 6. Stored Functions
+
+Some databases include pre-built stored functions (e.g., `Decrypt`, `Dekrypt`, `Verify`).
+
+### Discovering stored functions
+
+```kql
+// Management command — use kusto_command or kusto_list_entities(entity_type="functions")
+.show functions
+```
+
+### Invoking stored functions
+
+```kql
+// Call a stored function
+Decrypt(ciphertext, key)
+
+// Use in a query pipeline
+Logs
+| extend plaintext = Decrypt(EncryptedField, "MYKEY")
+| where plaintext contains "suspicious"
+```
+
+### Common pitfalls with stored functions
+
+1. **String escaping**: KQL uses single quotes for string literals. If the key contains special characters, use `@""` syntax:
+   ```kql
+   Decrypt(field, @"KEY'WITH'QUOTES")
+   ```
+2. **Argument types**: Ensure you pass the right type. If the function expects `string` and you have `dynamic`, cast with `tostring()`.
+3. **Function not found**: Check the database — functions are database-scoped. Use `.show functions` to list available ones.
+
+---
+
+## 7. Materialized Views & Caching
+
+### materialize() for subquery reuse
+
+When a subquery is referenced multiple times, `materialize()` computes it once:
+
+```kql
+let expensive_result = materialize(
+    HugeLogs
+    | where Timestamp > ago(1d)
+    | summarize count() by SourceIP
+    | where count_ > 1000
+);
+// Use it twice without recomputing
+expensive_result | summarize total = sum(count_)
+| union (expensive_result | top 10 by count_ desc)
+```
+
+### toscalar() for single-value subqueries
+
+```kql
+// Extract a single value to use as a constant
+let threshold = toscalar(Stats | summarize percentile(Value, 95));
+Events | where Value > threshold
+```
+
+### datatable for inline test data
+
+```kql
+// Create test data without touching the database
+let test_data = datatable(Name:string, Score:long) [
+    "Alice", 95,
+    "Bob", 87,
+    "Charlie", 92
+];
+test_data | where Score > 90
+```
+
+Use `datatable` + `print` to test transformations on small samples before running on full tables.

--- a/.github/skills/kql/references/error-recovery.md
+++ b/.github/skills/kql/references/error-recovery.md
@@ -1,0 +1,349 @@
+# Error Recovery Reference
+
+Complete mapping of common KQL error patterns. For each error: the exact message, a real query that triggered it, and the fix.
+
+## Table of Contents
+
+1. [E_LOW_MEMORY_CONDITION](#1-e_low_memory_condition)
+2. [Join Errors](#2-join-errors)
+3. [Network / Transient](#3-network--transient)
+4. [Dynamic Type Errors](#4-dynamic-type-errors)
+5. [Unresolved Names](#5-unresolved-names)
+6. [Syntax Errors](#6-syntax-errors)
+7. [String Comparison](#7-string-comparison)
+8. [extract_all Regex Groups](#8-extract_all-regex-groups)
+9. [Serialization Required](#9-serialization-required)
+10. [Missing Plugins](#10-missing-plugins)
+11. [graph-match Syntax](#11-graph-match-syntax)
+12. [E_RUNAWAY_QUERY](#12-e_runaway_query)
+
+---
+
+## 1. E_LOW_MEMORY_CONDITION
+
+**Error message**: `Query execution lacks memory resources to complete (80DA0007): Partial query failure: Low memory condition (E_LOW_MEMORY_CONDITION)`
+
+### Pattern A: Unfiltered aggregation on large table
+
+```kql
+// ❌ TRIGGERED ERROR — 24M rows, no pre-filter
+Consumption
+| summarize dcount(Consumed), count() by Timestamp, HouseholdId, MeterType
+| where dcount_Consumed > 1
+
+// ✅ FIX — filter first, reduce grouping columns
+Consumption
+| where Timestamp between (datetime(2023-04-15) .. datetime(2023-04-16))
+| summarize dcount(Consumed) by HouseholdId, MeterType
+| where dcount_Consumed > 1
+```
+
+### Pattern B: Join explosion
+
+```kql
+// ❌ TRIGGERED ERROR — 25K IPs × 195 polygons
+ip_locations
+| join kind=inner (Cities | where HackersCount >= 256) on $left.CityName == $right.CityName
+
+// ✅ FIX — pre-filter both sides, check cardinality first
+let filtered_ips = ip_locations | where CountryCode == "US" | summarize by CityName;
+let target_cities = Cities | where HackersCount >= 256 | project CityName;
+filtered_ips | join kind=inner target_cities on CityName
+```
+
+### Pattern C: High-cardinality dcount()
+
+```kql
+// ❌ TRIGGERED ERROR — Full distinct value enumeration
+Logs | summarize dcount(SourceIP), dcount(DestIP), dcount(Port) by bin(Timestamp, 1h)
+
+// ✅ FIX — use approximate counts or filter first
+Logs
+| where Timestamp > ago(1d)
+| summarize dcount(SourceIP) by bin(Timestamp, 1h)
+```
+
+**Recovery strategy**: When you see this error, your query is touching too much data. Options:
+1. Add `| where` time-range or partition filter
+2. Reduce `by` columns in `summarize`
+3. Break the query into smaller time windows
+4. Use `| sample 10000` for exploration
+
+---
+
+## 2. Join Errors
+
+### 2a. Left/right attribute mismatch
+
+**Error message**: `join: for each left attribute, right attribute should be selected.`
+
+```kql
+// ❌ TRIGGERED ERROR — incomplete on clause
+TableA | join kind=inner TableB on $left.Id
+
+// ✅ FIX — specify both sides
+TableA | join kind=inner TableB on $left.Id == $right.Id
+```
+
+```kql
+// ❌ TRIGGERED ERROR — expression in join condition
+TableA | join kind=inner TableB on $left.Id == $right.tolower(Name)
+
+// ✅ FIX — pre-compute the expression, join on the computed column
+TableA
+| join kind=inner (TableB | extend NameLower = tolower(Name)) on $left.Id == $right.NameLower
+```
+
+### 2b. Equality only
+
+**Error message**: `join: Only equality is allowed in this context.`
+
+```kql
+// ❌ TRIGGERED ERROR — geo-distance in join predicate
+TableA | join TableB on geo_distance_2points(a.Lat, a.Lon, b.Lat, b.Lon) < 1000
+
+// ✅ FIX — pre-bucket into spatial cells
+TableA
+| extend cell = geo_point_to_s2cell(Lon, Lat, 8)
+| join kind=inner (TableB | extend cell = geo_point_to_s2cell(Lon, Lat, 8)) on cell
+| where geo_distance_2points(Lat, Lon, Lat1, Lon1) < 1000  // post-filter for precision
+```
+
+```kql
+// ❌ TRIGGERED ERROR — range join
+Sales | join Thresholds on $left.Amount > $right.MinAmount
+
+// ✅ FIX — bin values and join on bins
+Sales
+| extend amount_bin = bin(Amount, 100)
+| join kind=inner (Thresholds | extend amount_bin = bin(MinAmount, 100)) on amount_bin
+| where Amount > MinAmount  // post-filter
+```
+
+---
+
+## 3. Network / Transient
+
+**Error message**: `Failed to process network request for the endpoint: https://kvc4bf3...`
+
+Cause: Corrupted cluster URIs or genuine network timeouts.
+
+**Recovery strategy**: 
+1. Verify the cluster URI is clean ASCII (no Unicode characters)
+2. Retry with a fresh URI
+3. If persistent, wait 30 seconds and retry (cluster may be overloaded)
+
+---
+
+## 4. Dynamic Type Errors
+
+### 4a. Summarize by dynamic
+
+**Error message**: `Summarize group key 'Area' is of a 'dynamic' type. Please use an explicit cast`
+
+```kql
+// ❌
+| summarize count() by Area
+// ✅
+| summarize count() by tostring(Area)
+```
+
+### 4b. Order by dynamic
+
+**Error message**: `order operator: key can't be of dynamic type`
+
+```kql
+// ❌
+| order by Properties.Score desc
+// ✅
+| order by todouble(Properties.Score) desc
+```
+
+### 4c. Join on dynamic
+
+**Error message**: `join key 'Area' is of a 'dynamic' type. Please use an explicit cast`
+
+```kql
+// ❌
+| join kind=inner other on Area
+// ✅
+| extend Area_str = tostring(Area)
+| join kind=inner (other | extend Area_str = tostring(Area)) on Area_str
+```
+
+---
+
+## 5. Unresolved Names
+
+**Error message**: `Failed to resolve column or scalar expression named 'X'` or `Failed to resolve entity 'X'`
+
+### Common causes
+
+| Cause | Example |
+|-------|---------|
+| Invented column name | `NewVIN` (doesn't exist; actual is `VIN`) |
+| Wrong table | Queried `Traffic` instead of `CarsTraffic` |
+| Table not yet ingested or in different database | Table not found |
+| Typo | `EstimatedHackersCount` vs actual column name |
+| Let-variable scope | Variable defined in different query |
+
+**Recovery strategy**:
+1. Use `kusto_describe_database_entity` to check exact column names
+2. Check exact table and column names — KQL is case-sensitive for column names
+3. If querying a table that should exist but doesn't, check which database you're connected to
+4. Most unresolved names are matchable against the cached schema — look for similar names
+
+---
+
+## 6. Syntax Errors
+
+### 6a. Management command in query pipe
+
+**Error message**: `Unexpected control command`
+
+```kql
+// ❌ — .show is a management command, don't pipe query operators onto it
+.show tables | project TableName
+
+// ✅ — use kusto_command for management commands, kusto_query for queries
+// Step 1: kusto_command(command=".show tables", ...)
+// Step 2: kusto_query(query="TableName | take 5", ...)
+```
+
+### 6b. Reserved words as identifiers
+
+**Error message**: `The name 'shards' needs to be bracketed as ['shards']`
+
+```kql
+// ❌
+let shards = ...
+
+// ✅
+let ['shards'] = ...
+// Or better: rename the variable
+let shard_info = ...
+```
+
+### 6c. Syntax: Expected comma
+
+Various syntax issues, usually from mixing SQL syntax into KQL:
+
+```kql
+// ❌ SQL-style
+SELECT * FROM Table WHERE x = 1
+
+// ✅ KQL-style
+Table | where x == 1
+```
+
+---
+
+## 7. String Comparison
+
+**Error message**: `Cannot compare values of types string and string. Try adding explicit casts`
+
+Despite both sides being strings, KQL sometimes requires explicit casts for computed values.
+
+```kql
+// ❌ — S2 cell comparison
+Runs
+| extend startCell = geo_point_to_s2cell(StartLon, StartLat, 16)
+| join kind=inner (...) on startCell
+
+// ✅ — explicit tostring()
+Runs
+| extend startCell = tostring(geo_point_to_s2cell(StartLon, StartLat, 16))
+| join kind=inner (... | extend startCell = tostring(geo_point_to_s2cell(Lon, Lat, 16))) on startCell
+```
+
+This occurs most often with `geo_point_to_s2cell()`, `hash()`, and `strcat()` return values.
+
+---
+
+## 8. extract_all Regex Groups
+
+**Error message**: `extractall(): argument 2 must be a valid regex with [1..16] matching groups`
+
+```kql
+// ❌ — Missing capturing group
+| extend words = extract_all(@"[a-zA-Z]{3,}", tolower(Title))
+
+// ✅ — Add parentheses
+| extend words = extract_all(@"([a-zA-Z]{3,})", tolower(Title))
+```
+
+Unlike Python's `re.findall()`, KQL's `extract_all` requires at least one `()` group.
+
+---
+
+## 9. Serialization Required
+
+**Error message**: `Function 'row_cumsum' cannot be invoked. The row set must be serialized.`
+
+```kql
+// ❌
+ChatServerLogs
+| summarize Online = sum(Direction) by bin(Timestamp, 5m)
+| extend CumulativeOnline = row_cumsum(Online)
+
+// ✅ — add order by (implicitly serializes)
+ChatServerLogs
+| summarize Online = sum(Direction) by bin(Timestamp, 5m)
+| order by Timestamp asc
+| extend CumulativeOnline = row_cumsum(Online)
+```
+
+Affected functions: `row_number()`, `row_cumsum()`, `prev()`, `next()`, `row_window_session()`.
+
+---
+
+## 10. Missing Plugins
+
+**Error message**: `plugin 'geo_point_in_polygon': plugin doesn't exist.`
+
+Some KQL functions are plugins that may not be enabled on free-tier clusters.
+
+**Recovery strategy**: Use the equivalent non-plugin function or fall back to Python for that specific operation.
+
+| Plugin | Status on free cluster | Alternative |
+|--------|----------------------|-------------|
+| `geo_point_in_polygon` (as plugin) | ❌ Not available | Use as scalar function: `geo_point_in_polygon(lon, lat, polygon)` |
+| `python` | ❌ Not available | Use local Python instead |
+
+---
+
+## 11. graph-match Syntax
+
+**Error message**: `graph-match operator: variable edge 'path' edges don't have property 'IsVulnerable'`
+
+```kql
+// ❌ — property access on variable-length edge
+graph-match (src)-[path*1..3]->(dst)
+  where path.IsVulnerable == true
+
+// ✅ — filter edges at definition, not traversal
+let edges = Edges | where IsVulnerable == true;
+graph(Nodes, edges)
+| graph-match (src)-[path*1..3]->(dst)
+  project src.Name, dst.Name
+```
+
+The fix is to pre-filter edges before graph construction.
+
+---
+
+## 12. E_RUNAWAY_QUERY
+
+**Error message**: `Runaway query (E_RUNAWAY_QUERY): Join output block exceeded memory budget`
+
+```kql
+// ❌ — 25K × 195 unconstrained cross-join
+ip_locs | join kind=inner (Cities | where EstimatedHackersCount >= 256) on ...
+
+// ✅ — check cardinality first, pre-filter aggressively
+// Step 1: ip_locs | summarize dcount(JoinKey)  → if >10K, add filters
+// Step 2: Cities | where EstimatedHackersCount >= 256 | count  → if >100, narrow criteria
+// Step 3: Then join
+```
+
+**Prevention**: Always `dcount()` both join sides before executing. If left × right > 1M, add filters.

--- a/.github/skills/kql/references/query-templates.md
+++ b/.github/skills/kql/references/query-templates.md
@@ -1,0 +1,336 @@
+# KQL Query Templates
+
+Reusable query patterns for common data investigation operations. Copy and adapt these.
+
+## Table of Contents
+
+1. [Deduplication](#1-deduplication)
+2. [Top-N Analysis](#2-top-n-analysis)
+3. [Time Binning & Trends](#3-time-binning--trends)
+4. [Pivoting](#4-pivoting)
+5. [Running Totals & Window Functions](#5-running-totals--window-functions)
+6. [Sessionization](#6-sessionization)
+7. [Cardinality Check Before Join](#7-cardinality-check-before-join)
+8. [Safe Exploration Pattern](#8-safe-exploration-pattern)
+9. [Diffing & Anomaly Detection](#9-diffing--anomaly-detection)
+10. [String Extraction Patterns](#10-string-extraction-patterns)
+
+---
+
+## 1. Deduplication
+
+### Exact deduplication
+```kql
+// Remove exact duplicate rows
+Table
+| distinct *
+```
+
+### Dedup keeping latest per key
+```kql
+// Keep the most recent record per entity
+Table
+| summarize arg_max(Timestamp, *) by EntityId
+```
+
+### Dedup keeping first per key
+```kql
+// Keep the earliest record per entity
+Table
+| summarize arg_min(Timestamp, *) by EntityId
+```
+
+### Count duplicates
+```kql
+// Find records that appear more than once
+Table
+| summarize cnt = count() by Col1, Col2, Col3
+| where cnt > 1
+| order by cnt desc
+```
+
+---
+
+## 2. Top-N Analysis
+
+### Top N by count
+```kql
+Table
+| summarize EventCount = count() by Category
+| top 10 by EventCount desc
+```
+
+### Top N by metric, with ties
+```kql
+Table
+| summarize TotalRevenue = sum(Amount) by Customer
+| order by TotalRevenue desc
+| take 10
+```
+
+### Top N per group
+```kql
+// Top 3 events per category
+Table
+| summarize EventCount = count() by Category, EventType
+| partition by Category (top 3 by EventCount desc)
+```
+
+### Bottom N (least common)
+```kql
+Table
+| summarize cnt = count() by Category
+| top 10 by cnt asc
+```
+
+---
+
+## 3. Time Binning & Trends
+
+### Hourly event counts
+```kql
+Events
+| summarize count() by bin(Timestamp, 1h)
+| order by Timestamp asc
+```
+
+### Day-over-day comparison
+```kql
+Events
+| where Timestamp > ago(14d)
+| summarize count() by Day = bin(Timestamp, 1d)
+| order by Day asc
+| extend PrevDayCount = prev(count_)
+| extend DayOverDayChange = count_ - PrevDayCount
+| serialize  // needed for prev()
+```
+
+### Activity by hour of day
+```kql
+Events
+| extend HourOfDay = datetime_part("hour", Timestamp)
+| summarize count() by HourOfDay
+| order by HourOfDay asc
+```
+
+### Activity by day of week
+```kql
+Events
+| extend DayOfWeek = dayofweek(Timestamp) / 1d
+| summarize count() by DayOfWeek
+| order by DayOfWeek asc
+```
+
+---
+
+## 4. Pivoting
+
+### Counts by category (pivot)
+```kql
+Events
+| evaluate pivot(Category, count(), bin(Timestamp, 1d))
+```
+
+### Manual pivot with summarize
+```kql
+Events
+| summarize
+    TypeA = countif(Type == "A"),
+    TypeB = countif(Type == "B"),
+    TypeC = countif(Type == "C")
+    by bin(Timestamp, 1h)
+```
+
+---
+
+## 5. Running Totals & Window Functions
+
+### Running total
+```kql
+Table
+| order by Timestamp asc
+| extend RunningTotal = row_cumsum(Value)
+```
+
+### Row numbers
+```kql
+Table
+| order by Score desc
+| extend Rank = row_number()
+```
+
+### Previous/next row comparison
+```kql
+Table
+| order by Timestamp asc
+| extend PrevValue = prev(Value), NextValue = next(Value)
+| extend Delta = Value - PrevValue
+```
+
+**Remember**: All these require serialized input — use `| order by` or `| serialize` before calling.
+
+---
+
+## 6. Sessionization
+
+### Gap-based sessions
+```kql
+// Group events into sessions (30-min idle gap)
+Events
+| order by UserId, Timestamp asc
+| extend SessionStart = row_window_session(Timestamp, 30m, 24h, UserId != prev(UserId))
+| summarize
+    SessionStart = min(Timestamp),
+    SessionEnd = max(Timestamp),
+    EventCount = count()
+    by UserId, SessionStart
+```
+
+### Sequential numbering within groups
+```kql
+Events
+| order by UserId, Timestamp asc
+| extend SeqNum = row_number(1, UserId != prev(UserId))
+```
+
+---
+
+## 7. Cardinality Check Before Join
+
+**Always run this before joining large tables:**
+
+```kql
+// Step 1: Check left side cardinality
+TableA | summarize LeftRows = count(), LeftDistinctKeys = dcount(JoinKey)
+
+// Step 2: Check right side cardinality
+TableB | summarize RightRows = count(), RightDistinctKeys = dcount(JoinKey)
+
+// Step 3: Estimate output size
+// If LeftDistinctKeys × RightDistinctKeys > 1M, add filters before joining
+
+// Step 4: Safe join with pre-filtering
+TableA
+| where Timestamp > ago(1d)  // narrow the time window
+| join kind=inner (
+    TableB | where IsActive == true  // narrow the right side too
+) on JoinKey
+```
+
+### Join kind selection guide
+
+| Kind | Behavior | Use when |
+|------|----------|----------|
+| `inner` | Only matching rows from both | Default choice |
+| `leftouter` | All left rows + matches from right | Need all left rows even without match |
+| `leftanti` | Left rows with NO match in right | Finding missing/orphan records |
+| `leftsemi` | Left rows that HAVE a match in right | Existence check (like SQL `EXISTS`) |
+| `fullouter` | All rows from both sides | Comparing two datasets |
+
+---
+
+## 8. Safe Exploration Pattern
+
+When encountering a new table, always follow this progression:
+
+```kql
+// Step 1: How big is it?
+Table | count
+
+// Step 2: What does it look like?
+Table | take 5
+
+// Step 3: What's the time range?
+Table | summarize min(Timestamp), max(Timestamp)
+
+// Step 4: What are the key dimensions?
+Table | summarize dcount(Col1), dcount(Col2), dcount(Col3)
+
+// Step 5: What's the value distribution?
+Table
+| summarize count() by Col1
+| top 10 by count_ desc
+```
+
+**Never skip to a complex query without running Steps 1-2 first.** Knowing the table size prevents memory errors; seeing sample rows prevents wrong assumptions about column values.
+
+**With MCP tools**: Use `kusto_sample_entity` for Step 2 and `kusto_describe_database_entity` to understand the schema before querying.
+
+---
+
+## 9. Diffing & Anomaly Detection
+
+### Find outliers by standard deviation
+```kql
+Table
+| summarize avg_val = avg(Value), stdev_val = stdev(Value)
+| join kind=inner Table on true()
+| where Value > avg_val + 3 * stdev_val or Value < avg_val - 3 * stdev_val
+```
+
+### Compare two time periods
+```kql
+let period1 = Table | where Timestamp between (datetime(2023-01-01) .. datetime(2023-01-31));
+let period2 = Table | where Timestamp between (datetime(2023-02-01) .. datetime(2023-02-28));
+period1 | summarize P1_Count = count() by Category
+| join kind=fullouter (period2 | summarize P2_Count = count() by Category) on Category
+| extend Change = P2_Count - P1_Count, ChangePercent = round(100.0 * (P2_Count - P1_Count) / P1_Count, 1)
+```
+
+### Find records that appear in one table but not another
+```kql
+// Records in A but not in B
+TableA | join kind=leftanti TableB on Key
+```
+
+### Find new entities (appeared after a cutoff)
+```kql
+let cutoff = datetime(2023-06-01);
+Table
+| summarize FirstSeen = min(Timestamp) by EntityId
+| where FirstSeen > cutoff
+```
+
+---
+
+## 10. String Extraction Patterns
+
+### Extract structured fields
+```kql
+// Parse key=value pairs
+Logs | parse Message with * "user=" User " " * "action=" Action " " *
+
+// Extract with regex
+Logs | extend IP = extract(@"(\d+\.\d+\.\d+\.\d+)", 1, Message)
+
+// Extract all matches (remember: needs capturing groups!)
+Logs | extend AllIPs = extract_all(@"(\d+\.\d+\.\d+\.\d+)", Message)
+```
+
+### Split and expand
+```kql
+// Split a delimited string and expand into rows
+Table
+| extend Parts = split(DelimitedField, ",")
+| mv-expand Part = Parts to typeof(string)
+```
+
+### URL parsing
+```kql
+Logs
+| extend Host = parse_url(Url).Host
+| extend Path = parse_url(Url).Path
+| extend QueryParams = parse_url(Url).["Query Parameters"]
+```
+
+### JSON field extraction
+```kql
+// Direct property access
+Logs | extend UserId = tostring(Properties.userId)
+
+// Nested JSON
+Logs | extend City = tostring(Properties.address.city)
+
+// Parse JSON string
+Logs | extend Parsed = parse_json(JsonString) | extend Name = tostring(Parsed.name)
+```

--- a/README.md
+++ b/README.md
@@ -76,24 +76,22 @@ The skill references the Fabric RTI MCP tools (`kusto_query`, `kusto_command`, `
 - "Create a teams alert to notify me when my success rate drops below 95%"
 - "List all Activator artifacts in my workspace"
 
-**Map Visualization::**
+**Map Visualization:**
 - "List all Map items in my workspace"
 - "Create a new Map and add LakeHouse with name 'MyLakeHouse' as a data source to Map item 'MyMap'"
 - "Delete a Map item with name 'MyMap' from my workspace"
 
 ### Available tools
 
-#### Eventhouse (Kusto) - 13 Tools:
+#### Eventhouse (Kusto) - 11 Tools:
 - **`kusto_known_services`** - List all available Kusto services configured in the MCP
 - **`kusto_query`** - Execute KQL queries on the specified database
-- **`kusto_command`** - Execute Kusto management commands (destructive operations)
-- **`kusto_list_databases`** - List all databases in the Kusto cluster
-- **`kusto_list_tables`** - List all tables in a specified database
-- **`kusto_get_entities_schema`** - Get schema information for all entities (tables, external tables, materialized views, functions) in a database
-- **`kusto_get_table_schema`** - Get detailed schema information for a specific table
-- **`kusto_get_function_schema`** - Get schema information for a specific function, including parameters and output schema
-- **`kusto_sample_table_data`** - Retrieve random sample records from a specified table
-- **`kusto_sample_function_data`** - Retrieve random sample records from the result of a function call
+- **`kusto_command`** - Execute Kusto management commands (`.show`, `.create`, `.alter`, `.drop`)
+- **`kusto_list_entities`** - List entities (databases, tables, external tables, materialized views, functions, graphs) in a cluster or database
+- **`kusto_describe_database`** - Get schema information for all entities in a database
+- **`kusto_describe_database_entity`** - Get detailed schema for a specific entity (table, external table, materialized view, function, graph)
+- **`kusto_graph_query`** - Execute graph queries using snapshots or transient graphs
+- **`kusto_sample_entity`** - Retrieve sample records from a table, external table, materialized view, or function
 - **`kusto_ingest_inline_into_table`** - Ingest inline CSV data into a specified table
 - **`kusto_get_shots`** - Retrieve semantically similar query examples from a shots table using AI embeddings
 - **`kusto_deeplink_from_query`** - Generate a deeplink URL to open a KQL query in Azure Data Explorer Web Explorer or Microsoft Fabric query workbench
@@ -161,7 +159,7 @@ The process should end with the below settings in your `settings.json` or your `
 ```json
 {
     "mcp": {
-        "server": {
+        "servers": {
             "fabric-rti-mcp": {
                 "command": "uvx",
                 "args": [
@@ -170,7 +168,7 @@ The process should end with the below settings in your `settings.json` or your `
                 "env": {
                     "KUSTO_SERVICE_URI": "https://help.kusto.windows.net/",
                     "KUSTO_SERVICE_DEFAULT_DB": "Samples",
-                    "FABRIC_API_BASE_URL": "https://api.fabric.microsoft.com/v1"
+                    "FABRIC_API_BASE": "https://api.fabric.microsoft.com/v1"
                 }
             }
         }
@@ -201,7 +199,7 @@ Or manually add to your `~/.copilot/mcp-config.json`:
             "env": {
                 "KUSTO_SERVICE_URI": "https://help.kusto.windows.net/",
                 "KUSTO_SERVICE_DEFAULT_DB": "Samples",
-                "FABRIC_API_BASE_URL": "https://api.fabric.microsoft.com/v1"
+                "FABRIC_API_BASE": "https://api.fabric.microsoft.com/v1"
             }
         }
     }
@@ -237,7 +235,7 @@ For more information, see the [GitHub Copilot CLI documentation](https://docs.gi
                 "env": {
                     "KUSTO_SERVICE_URI": "https://help.kusto.windows.net/",
                     "KUSTO_SERVICE_DEFAULT_DB": "Samples",
-                    "FABRIC_API_BASE_URL": "https://api.fabric.microsoft.com/v1"
+                    "FABRIC_API_BASE": "https://api.fabric.microsoft.com/v1"
                 }
             }
         }
@@ -275,27 +273,7 @@ Once VS Code picks up the server and starts it, navigate to its output:
 3. Try prompts that tell the agent to use the RTI tools, such as:
    - **Eventhouse**: "List my Kusto tables" or "Show me a sample from the StormEvents table"
    - **Eventstreams**: "List all Eventstreams in my workspace" or "Show me details of my data processing Eventstream"
-4. The agent should be able use the Fabric RTI MCP Server tools to complete your query
-
-### Via VS Code Client Tool
-For direct testing and development, use the included VS Code client:
-
-```bash
-# Interactive mode with menu
-python eventstream_test/vscode_mcp_client.py
-
-# Natural language commands
-python eventstream_test/vscode_mcp_client.py "list eventstreams in workspace abc-123 with interactive auth"
-python eventstream_test/vscode_mcp_client.py "query cluster https://example.kusto.windows.net: MyTable | take 10"
-python eventstream_test/vscode_mcp_client.py "get fabric api base url"
-```
-
-The VS Code client includes:
-- 🔐 **Interactive authentication** - Browser-based Microsoft sign-in
-- 🗣️ **Natural language prompts** - English commands for MCP operations  
-- ⚙️ **API configuration** - Runtime control of Fabric API endpoints
-- 📊 **JSON output** - Formatted results for analysis
-
+4. The agent should be able to use the Fabric RTI MCP Server tools to complete your query
 
 ## ⚙️ Configuration
 
@@ -335,7 +313,7 @@ https://{your-openai-resource}.openai.azure.com/openai/deployments/{deployment-n
 
 **Authentication Requirements:**
 - Your Azure identity must have access to the OpenAI resource
-- In case using managed identity, the OpenAI resource must should be configured to accept managed identity authentication
+- In case of using managed identity, the OpenAI resource must be configured to accept managed identity authentication
 - The deployment must exist and be accessible
 
 ### Configuration of Shots Table
@@ -388,7 +366,7 @@ If your scenario involves a user token with a non-Kusto audience and you need to
 | Variable | Description | Default | Example |
 |----------|-------------|---------|---------|
 | `USE_OBO_FLOW` | Enable OBO flow for token exchange | `false` | `true` |
-| `FABRIC_RTI_MCP_AZURE_TENANT_ID` | `72f988bf-86f1-41af-91ab-2d7cd011db47` (Microsoft) | `72f988bf-86f1-41af-91ab-2d7cd011db47` |
+| `FABRIC_RTI_MCP_AZURE_TENANT_ID` | Azure AD tenant ID | `72f988bf-86f1-41af-91ab-2d7cd011db47` (Microsoft) | `72f988bf-86f1-41af-91ab-2d7cd011db47` |
 | `FABRIC_RTI_MCP_ENTRA_APP_CLIENT_ID` | Entra App (AAD) Client ID | Your client ID |
 | `FABRIC_RTI_MCP_USER_MANAGED_IDENTITY_CLIENT_ID` | User Managed Identity Client ID | Your UMI client ID |
 
@@ -424,11 +402,8 @@ contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additio
 
 ## 📚 Documentation
 
-- **[Usage Guide](./USAGE_GUIDE.md)** - Comprehensive examples and scenarios
-- **[Architecture Guide](./ARCHITECTURE.md)** - Technical architecture and design patterns  
-- **[Async Pattern Explanation](./ASYNC_PATTERN_EXPLANATION.md)** - Details on async/sync integration
 - **[Changelog](./CHANGELOG.md)** - Release history and breaking changes
-- **[Project Assessment](./POST_CLEANUP_ASSESSMENT.md)** - Current project health status
+- **[Contributing](./CONTRIB.md)** - Contribution guidelines
 
 ## Data Collection
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,19 @@ The Fabric RTI MCP Server acts as a bridge between AI agents and Microsoft Fabri
 - List Map items in workspaces
 - Delete Map items
 
+### 🧠 Copilot Skills
+
+This repository includes a **KQL Copilot Skill** (`.github/skills/kql/`) that gives AI agents deep KQL expertise when writing, debugging, or reviewing Kusto queries. The skill covers:
+
+- Syntax gotchas and self-correction patterns for common KQL errors
+- Dynamic type discipline, join patterns, datetime pitfalls
+- Memory-safe query patterns and result-size discipline
+- Advanced functions: graph queries, vector similarity, geospatial operations, time series
+- Query templates for deduplication, top-N, sessionization, pivoting, and more
+- Full error-to-fix mapping for rapid recovery
+
+The skill references the Fabric RTI MCP tools (`kusto_query`, `kusto_command`, `kusto_sample_entity`, etc.) so agents know how to execute queries through this MCP server.
+
 ## 🚧 Coming soon
 - **Other RTI items**
 


### PR DESCRIPTION
## Summary

Adds a **KQL Copilot Skill** that gives AI agents deep KQL expertise when working with this MCP server, and fixes several stale/broken items in the README.

### KQL Skill (`.github/skills/kql/`)

- **SKILL.md** — KQL mastery skill covering syntax gotchas, dynamic types, joins, datetime pitfalls, regex, serialization, memory-safe patterns, result-size discipline, error recovery, and a query writing checklist. Section 1 documents all Fabric RTI MCP tools (`kusto_query`, `kusto_command`, `kusto_sample_entity`, etc.) with usage examples.
- **references/advanced-patterns.md** — Graph queries, vector similarity, geospatial ops, time series, external data, stored functions, materialized views.
- **references/error-recovery.md** — Complete error-to-fix mapping for 12 common KQL error categories.
- **references/query-templates.md** — Reusable patterns for deduplication, top-N, pivoting, sessionization, joins, anomaly detection, and string extraction.

Adapted from [danield137/ku](https://github.com/danield137/ku), with all `ku` CLI references replaced by Fabric RTI MCP tool equivalents.

### README Fixes

- **Stale tool names** — Updated Eventhouse tool list from 13 old names to 11 actual names matching `kusto_tools.py`
- **`"server"` → `"servers"`** — Fixed singular typo in settings.json example
- **`FABRIC_API_BASE_URL` → `FABRIC_API_BASE`** — Fixed env var name in all 3 install examples
- **Dead doc links** — Removed 4 links to nonexistent files (USAGE_GUIDE, ARCHITECTURE, ASYNC_PATTERN, POST_CLEANUP)
- **Nonexistent `eventstream_test/` section** — Removed VS Code Client Tool section referencing missing directory
- **OBO table** — Added missing description for `FABRIC_RTI_MCP_AZURE_TENANT_ID`
- **Typos/grammar** — Fixed double colon, "must should be", "able use"
