### PR TITLE
feat: expose CORS allowed origins as FABRIC_RTI_CORS_ORIGINS env var

### DIFF
--- a/fabric_rti_mcp/authentication/auth_middleware.py
+++ b/fabric_rti_mcp/authentication/auth_middleware.py
@@ -92,7 +92,7 @@ def add_auth_middleware(fastmcp: FastMCP) -> None:
         # Add CORS middleware
         app.add_middleware(
             CORSMiddleware,  # ty: ignore[invalid-argument-type]
-            allow_origins=["*"],  # Allows all origins
+            allow_origins=[o.strip() for o in config.cors_allowed_origins.split(",")],
             allow_credentials=True,
             allow_methods=["*"],  # Allows all methods
             allow_headers=["*"],  # Allows all headers

--- a/fabric_rti_mcp/config/__init__.py
+++ b/fabric_rti_mcp/config/__init__.py
@@ -21,6 +21,7 @@ class GlobalFabricRTIEnvVarNames:
     stateless_http = "FABRIC_RTI_STATELESS_HTTP"
     use_obo_flow = "USE_OBO_FLOW"
     use_ai_foundry_compat = "FABRIC_RTI_AI_FOUNDRY_COMPATIBILITY_SCHEMA"
+    cors_allowed_origins = "FABRIC_RTI_CORS_ORIGINS"
 
 
 DEFAULT_FABRIC_API_BASE = "https://api.fabric.microsoft.com/v1"
@@ -32,6 +33,7 @@ DEFAULT_FABRIC_RTI_HTTP_HOST = "127.0.0.1"
 DEFAULT_FABRIC_RTI_STATELESS_HTTP = False
 DEFAULT_USE_OBO_FLOW = False
 DEFAULT_FABRIC_RTI_AI_FOUNDRY_COMPATIBILITY_SCHEMA = False
+DEFAULT_FABRIC_RTI_CORS_ORIGINS = "*"
 
 
 @dataclass(slots=True, frozen=True)
@@ -45,6 +47,7 @@ class GlobalFabricRTIConfig:
     stateless_http: bool
     use_obo_flow: bool
     use_ai_foundry_compat: bool
+    cors_allowed_origins: str
 
     @staticmethod
     def from_env() -> GlobalFabricRTIConfig:
@@ -67,6 +70,9 @@ class GlobalFabricRTIConfig:
             use_obo_flow=os.getenv(GlobalFabricRTIEnvVarNames.use_obo_flow, "false").lower() in ("true", "1"),
             use_ai_foundry_compat=os.getenv(GlobalFabricRTIEnvVarNames.use_ai_foundry_compat, "false").lower()
             in ("true", "1"),
+            cors_allowed_origins=os.getenv(
+                GlobalFabricRTIEnvVarNames.cors_allowed_origins, DEFAULT_FABRIC_RTI_CORS_ORIGINS
+            ),
         )
 
     @staticmethod
@@ -83,6 +89,7 @@ class GlobalFabricRTIConfig:
             GlobalFabricRTIEnvVarNames.stateless_http,
             GlobalFabricRTIEnvVarNames.use_obo_flow,
             GlobalFabricRTIEnvVarNames.use_ai_foundry_compat,
+            GlobalFabricRTIEnvVarNames.cors_allowed_origins,
         ]
         for env_var in env_vars:
             if os.getenv(env_var) is not None:
@@ -130,6 +137,7 @@ class GlobalFabricRTIConfig:
             stateless_http=stateless_http,
             use_obo_flow=use_obo_flow,
             use_ai_foundry_compat=use_ai_foundry_compat,
+            cors_allowed_origins=base_config.cors_allowed_origins,
         )
 
 

--- a/tests/unit/test_global_config.py
+++ b/tests/unit/test_global_config.py
@@ -58,6 +58,21 @@ class TestFromEnvBooleanParsing:
         config = GlobalFabricRTIConfig.from_env()
         assert config.use_ai_foundry_compat is False
 
+    @patch.dict("os.environ", {}, clear=False)
+    def test_cors_allowed_origins_defaults_to_wildcard(self) -> None:
+        import os
+
+        os.environ.pop("FABRIC_RTI_CORS_ORIGINS", None)
+        config = GlobalFabricRTIConfig.from_env()
+        assert config.cors_allowed_origins == "*"
+
+    @patch.dict("os.environ", {"FABRIC_RTI_CORS_ORIGINS": "https://example.com,https://other.com"}, clear=False)
+    def test_cors_allowed_origins_custom_value(self) -> None:
+        config = GlobalFabricRTIConfig.from_env()
+        assert config.cors_allowed_origins == "https://example.com,https://other.com"
+        origins = [o.strip() for o in config.cors_allowed_origins.split(",")]
+        assert origins == ["https://example.com", "https://other.com"]
+
 
 class TestWithArgsCLIOverride:
     @patch.dict("os.environ", {"USE_OBO_FLOW": "true"}, clear=False)


### PR DESCRIPTION
## Summary

Expose CORS allowed origins as a configurable environment variable instead of hardcoded wildcard.

## Changes

- Added `FABRIC_RTI_CORS_ORIGINS` env var to `GlobalFabricRTIConfig` (default: `*`)
- `auth_middleware.py` reads from config, splits comma-separated origins
- Two new tests: default wildcard and custom comma-separated origins

## Usage

Default (unchanged behavior):
`FABRIC_RTI_CORS_ORIGINS` not set -> allows all origins

Hardened deployment:
`FABRIC_RTI_CORS_ORIGINS=https://app.example.com,https://other.com`