### PR TITLE
fix(kql): apply KQL skill corrections and add new content

### DIFF
--- a/.github/skills/kql/SKILL.md
+++ b/.github/skills/kql/SKILL.md
@@ -5,6 +5,9 @@ description: "KQL language expertise for writing correct, efficient Kusto querie
 
 # KQL Mastery
 
+> **Try it yourself**: All `✅` examples in this skill can be run against the public help cluster:
+> `https://help.kusto.windows.net`, database `Samples` (contains `StormEvents`, `SimpleGraph_Nodes`/`Edges`, `nyc_taxi`, and more).
+
 ## 1. Running KQL with Fabric RTI MCP
 
 Fabric RTI MCP exposes Kusto functionality as MCP tools. Authentication is handled transparently using Azure Identity.
@@ -187,7 +190,7 @@ Unlike Python's `re.findall()`, KQL's `extract_all` **requires capturing groups*
 | `extract_all(regex, source)` | All matches (needs `()`) | `extract_all(@"(\w+)", Text)` |
 | `parse` | Structured extraction | `parse Msg with * "User '" Sender "' sent" *` |
 | `matches regex` | Boolean filter | `where Url matches regex @"^https?://"` |
-| `replace_regex` | Find and replace | `replace_regex(@"\s+", " ", Text)` |
+| `replace_regex` | Find and replace | `replace_regex(Text, @"\s+", " ")` |
 
 ## 5. Serialization Requirements
 
@@ -275,7 +278,7 @@ KQL sometimes requires explicit casts when comparing computed string values — 
 | where tostring(geo_point_to_s2cell(Lon, Lat, 16)) == tostring(other_cell)
 ```
 
-This is most common with computed values from `geo_point_to_s2cell()`, `hash()`, and `strcat()` comparisons. When in doubt, cast with `tostring()`.
+This is most common with computed values from `geo_point_to_s2cell()` and `strcat()` comparisons. When in doubt, cast with `tostring()`.
 
 ## 9. Advanced Functions
 
@@ -283,22 +286,21 @@ KQL handles these natively — no need for Python:
 
 ### Vector similarity
 ```kql
-// Don't export vectors and compute cosine similarity in Python
-let target = toscalar(Vectors | where Word == "test" | project Vec);
-Data | extend sim = series_cosine_similarity(parse_json(VecColumn), target)
-| top 10 by sim desc
+// try it! — cosine similarity on Iris feature vectors
+let target = pack_array(5.1, 3.5, 1.4, 0.2);
+Iris
+| extend Vec = pack_array(SepalLength, SepalWidth, PetalLength, PetalWidth)
+| extend sim = series_cosine_similarity(Vec, target)
+| top 5 by sim desc
 ```
 
 ### Geo operations
 ```kql
-// Point-in-polygon check
-| where geo_point_in_polygon(Longitude, Latitude, dynamic({"type":"Polygon","coordinates":[...]}))
-
 // Distance between two points (meters)
-| extend dist = geo_distance_2points(Lon1, Lat1, Lon2, Lat2)
+StormEvents | extend dist = geo_distance_2points(BeginLon, BeginLat, EndLon, EndLat)
 
 // Spatial bucketing for joins
-| extend cell = geo_point_to_s2cell(Lon, Lat, 8)
+StormEvents | extend cell = geo_point_to_s2cell(BeginLon, BeginLat, 8)
 ```
 
 ### Graph queries
@@ -306,17 +308,25 @@ Data | extend sim = series_cosine_similarity(parse_json(VecColumn), target)
 Use the `kusto_graph_query` MCP tool for graph traversal. It automatically handles graph snapshots when available:
 
 ```kql
-// Build and traverse a graph
-graph(Nodes, Edges)
+// Persistent graph model — query the latest snapshot
+graph("Simple")
 | graph-match (src)-[e*1..5]->(dst)
-  where src.Name == "start" and dst.IsTarget == true
-  project src.Name, dst.Name, path_length = array_length(e)
+  where src.name == "Alice"
+  project src.name, dst.name, path_length = array_length(e)
+
+// Transient graph — build inline with make-graph
+SimpleGraph_Edges
+| make-graph source --> target with SimpleGraph_Nodes on id
+| graph-match (src)-[e*1..5]->(dst)
+  where src.name == "Alice"
+  project src.name, dst.name, path_length = array_length(e)
 ```
 
 ### Time series
 ```kql
 // Create a time series and detect anomalies
-| make-series count() default=0 on Timestamp step 1h
+StormEvents
+| make-series count() default=0 on StartTime step 1d
 | extend anomalies = series_decompose_anomalies(count_)
 ```
 
@@ -365,15 +375,15 @@ Datetime literals are a common source of errors. A wrong literal format can casc
 | where datetime_part("year", StartTime) == 2007
 
 // ✅ ALSO RIGHT — use between with datetime range
-| where StartTime between (datetime(2007-01-01) .. datetime(2007-12-31))
+| where StartTime between (datetime(2007-01-01) .. datetime(2007-12-31T23:59:59))
 ```
 
 ### Time bucketing in summarize
 ```kql
-// ❌ WRONG — complex expression directly in by-clause can fail in some engines
+// This works, but can be harder to read and reuse in complex queries
 | summarize count() by startofmonth(StartTime)
 
-// ✅ SAFER — extend first, then summarize by the computed column
+// Clearer — extend first, then summarize by the computed column
 | extend Month = startofmonth(StartTime)
 | summarize count() by Month
 | order by Month asc
@@ -382,18 +392,28 @@ Datetime literals are a common source of errors. A wrong literal format can casc
 ### Useful datetime functions
 | Function | Purpose | Example |
 |----------|---------|---------|
-| `bin(ts, 1h)` | Round to nearest bucket | `bin(Timestamp, 1d)` |
+| `bin(ts, 1h)` | Round down to bucket boundary | `bin(Timestamp, 1d)` |
 | `startofmonth(ts)` | First day of month | `startofmonth(Timestamp)` |
 | `datetime_part("hour", ts)` | Extract component | `datetime_part("year", Timestamp)` |
 | `format_datetime(ts, fmt)` | Format as string | `format_datetime(Timestamp, "yyyy-MM")` |
-| `ago(1d)` | Relative time | `where Timestamp > ago(7d)` |
-| `between(a .. b)` | Range filter | `where Timestamp between (datetime(2024-01-01) .. datetime(2024-01-31))` |
+| `ago(1d)` | Relative time | `where Timestamp > ago(1d)` |
+| `between(a .. b)` | Range filter (inclusive) | `where Timestamp between (datetime(2024-01-01) .. datetime(2024-01-31T23:59:59))` |
 | `todatetime(str)` | Parse string → datetime | `todatetime("2024-01-15T10:30:00Z")` |
 | `totimespan(str)` | Parse string → timespan | `totimespan("01:30:00")` |
 
 ## 12. Operator Naming & Equality
 
 KQL has subtle differences from SQL syntax.
+
+### Naming conventions
+
+| Entity | Convention | Example |
+|--------|-----------|---------|
+| Tables | UpperCamelCase | `StormEvents`, `NetworkLogs` |
+| Columns | UpperCamelCase | `StartTime`, `EventType` |
+| Variables (`let`) | snake_case | `let filtered_events = ...` |
+| Built-in functions | snake_case | `format_bytes()`, `geo_distance_2points()` |
+| Stored functions | UpperCamelCase | `.create function GetTopUsers` |
 
 ### Equality operators
 ```kql

--- a/.github/skills/kql/references/advanced-patterns.md
+++ b/.github/skills/kql/references/advanced-patterns.md
@@ -2,6 +2,9 @@
 
 Reference for specialized KQL features: graph queries, vector similarity, geospatial operations, time series, and external data. Consult this when a task requires these capabilities.
 
+> **Try it yourself**: Examples marked with `// try it!` can be run on the public help cluster:
+> `https://help.kusto.windows.net`, database `Samples`.
+
 ## Table of Contents
 
 1. [Graph Queries](#1-graph-queries)
@@ -11,78 +14,151 @@ Reference for specialized KQL features: graph queries, vector similarity, geospa
 5. [External Data](#5-external-data)
 6. [Stored Functions](#6-stored-functions)
 7. [Materialized Views & Caching](#7-materialized-views--caching)
+8. [Good Query Habits](#8-good-query-habits)
 
 ---
 
 ## 1. Graph Queries
 
-KQL's graph model requires building a graph from node/edge tables, then traversing with `graph-match`.
+KQL supports two approaches for building and querying graphs. The `graph-match` syntax is the same for both — only how the graph is constructed differs.
+- **Transient graphs** — built inline with the `make-graph` operator. Useful for verifying an approach before committing to persistent graph building, or for smaller graphs (~1M entities).
+- **Persistent (snapshot) graphs** — defined as a graph model and queried with `graph("ModelName")`. Best for large graphs and repeated queries where rebuilding the graph each time is too expensive.
 
-### Building a graph
+### Querying a persistent graph model
+
+Persistent graph models are defined once and queried repeatedly with `graph("ModelName")`. The function picks up the latest snapshot automatically. You can also target a specific snapshot with `graph("ModelName", "SnapshotName")`.
 
 ```kql
-// Define nodes and edges
-let nodes = YaccApplications | project NodeId = AppId, AppName, HostingIp;
-let edges = YaccConnections | project SourceId = SourceAppId, TargetId = TargetAppId, Protocol, Port;
-
-// Build and query
-graph(nodes, edges)
+// try it! — query the persistent "Simple" graph model on the help cluster
+graph("Simple")
 | graph-match (src)-[e]->(dst)
-  where src.AppName == "Gateway"
-  project src.AppName, dst.AppName, e.Protocol
+  where src.name == "Alice"
+  project src.name, dst.name, e.lbl
+```
+
+### Creating a persistent graph model
+
+Use `.create-or-alter graph_model` to define the schema and how nodes/edges are built from tables:
+
+````kql
+// Management command — define the graph model
+.create-or-alter graph_model YaccNetwork ```
+{
+  "Schema": {
+    "Nodes": {
+      "Application": {"AppName": "string", "HostingIp": "string"}
+    },
+    "Edges": {
+      "Connection": {"Protocol": "string", "Port": "int"}
+    }
+  },
+  "Definition": {
+    "Steps": [
+      {
+        "Kind": "AddNodes",
+        "Query": "YaccApplications | project NodeId = AppId, AppName, HostingIp",
+        "NodeIdColumn": "NodeId",
+        "Labels": ["Application"]
+      },
+      {
+        "Kind": "AddEdges",
+        "Query": "YaccConnections | project SourceId = SourceAppId, TargetId = TargetAppId, Protocol, Port",
+        "SourceColumn": "SourceId",
+        "TargetColumn": "TargetId",
+        "Labels": ["Connection"]
+      }
+    ]
+  }
+}
+```
+````
+
+### Ad-hoc graphs with make-graph
+
+For one-time analysis, use the `make-graph` operator to build a transient graph inline:
+
+```kql
+// try it! — uses SimpleGraph_Nodes and SimpleGraph_Edges from help cluster
+SimpleGraph_Edges
+| make-graph source --> target with SimpleGraph_Nodes on id
+| graph-match (src)-[e]->(dst)
+  where src.name == "Alice"
+  project src.name, dst.name, e.lbl
 ```
 
 ### Variable-length traversal
 
 ```kql
-// Find all paths up to 5 hops from a start node
-graph(nodes, edges)
-| graph-match (start)-[path*1..5]->(target)
-  where start.AppName == "Frontend"
-  project start.AppName, target.AppName, hops = array_length(path)
+// try it! — find all paths up to 3 hops from Alice on persistent model
+graph("Simple")
+| graph-match (start)-[path*1..3]->(target)
+  where start.name == "Alice"
+  project start.name, target.name, hops = array_length(path)
+| take 10
 ```
 
 ### Pre-filtering edges (the key pattern)
 
-Important: **filter edges BEFORE building the graph**, not during traversal. Edge properties are not accessible on variable-length paths during `graph-match`.
+Edge properties are not accessible on variable-length paths during `graph-match`. Use `all()` / `any()` for label-based filtering, or pre-filter edges before building the graph.
 
 ```kql
 // ❌ WRONG — can't access properties on variable-length edge
 graph-match (src)-[path*1..3]->(dst)
   where path.IsVulnerable == true
 
-// ✅ RIGHT — pre-filter edges
-let vulnerable_edges = Edges | where IsVulnerable == true;
-graph(Nodes, vulnerable_edges)
+// ✅ RIGHT (persistent) — filter in graph model definition
+// In the AddEdges step, set Query to: "Edges | where IsVulnerable == true | project ..."
+
+// ✅ RIGHT (ad-hoc) — pre-filter edges before make-graph
+Edges
+| where IsVulnerable == true
+| make-graph SourceId --> TargetId with Nodes on NodeId
 | graph-match (src)-[path*1..3]->(dst)
   project src.Name, dst.Name
-```
 
-### Persistent graph snapshots
-
-For repeated traversals, create a snapshot:
-
-```kql
-// Create once (management command)
-.create graph-snapshot MyGraph
-  <| graph(nodes, edges)
-
-// Query repeatedly
+// ✅ RIGHT (label-based) — use all() on variable-length paths
 graph("MyGraph")
-| graph-match (src)-[e]->(dst)
-  where src.Type == "Server"
+| graph-match (src)-[path*1..3]->(dst)
+  where all(path, labels() has "Vulnerable")
   project src.Name, dst.Name
 ```
 
-### graph-to-table for post-processing
+### Graph snapshots
+
+For persistent models, create materialized snapshots for faster queries:
 
 ```kql
-graph(nodes, edges)
+// Create a snapshot (management command, async — not runnable on help cluster)
+.make graph_snapshot Simple_20240115
+  with (source = graph_model("Simple"))
+
+// try it! — query picks up latest snapshot automatically
+graph("Simple")
 | graph-match (src)-[e]->(dst)
-  project src.Name, dst.Name, e.Weight
-| graph-to-table
-| summarize TotalWeight = sum(Weight) by src_Name
-| top 10 by TotalWeight desc
+  where labels(src) has "Person"
+  project src.name, dst.name, e.lbl
+| take 10
+```
+
+### Post-processing graph results
+
+After `graph-match` with a `project` clause, results are tabular and can be piped to any KQL operator:
+
+```kql
+// try it! — count relationships per person
+graph("Simple")
+| graph-match (src)-[e]->(dst)
+  project src.name, dst.name, e.lbl
+| summarize ConnectionCount = count() by src_name
+| top 10 by ConnectionCount desc
+```
+
+Use the `graph-to-table` operator when you need to export all nodes and edges from a graph as raw tables (without pattern matching):
+
+```kql
+graph("Simple")
+| graph-to-table nodes as N, edges as E;
+N | take 5
 ```
 
 ---
@@ -96,22 +172,22 @@ KQL has native vector operations — **don't export to Python** for cosine simil
 The most common vector operation.
 
 ```kql
-// Find the most similar items to a target vector
-let target_vec = toscalar(
-    Embeddings | where Word == "test" | project Vec
-);
-Embeddings
-| extend similarity = series_cosine_similarity(parse_json(Vec), target_vec)
-| top 10 by similarity desc
+// try it! — find Iris flowers most similar to a target using feature vectors
+let target_vec = pack_array(5.1, 3.5, 1.4, 0.2);
+Iris
+| extend Vec = pack_array(SepalLength, SepalWidth, PetalLength, PetalWidth)
+| extend similarity = series_cosine_similarity(Vec, target_vec)
+| top 5 by similarity desc
+| project Class, SepalLength, SepalWidth, similarity
 ```
 
 ### Combining vectors
 
 ```kql
-// Weighted vector combination (e.g., word1 * 0.5 + word2 * 0.3 + word3 * 0.2)
-let v1 = toscalar(Vecs | where Word == "hello" | project Vec);
-let v2 = toscalar(Vecs | where Word == "world" | project Vec);
-let v3 = toscalar(Vecs | where Word == "test" | project Vec);
+// try it! — weighted vector combination from Iris feature vectors
+let v1 = toscalar(Iris | where Class == "Iris-setosa" | take 1 | project pack_array(SepalLength, SepalWidth, PetalLength, PetalWidth));
+let v2 = toscalar(Iris | where Class == "Iris-versicolor" | take 1 | project pack_array(SepalLength, SepalWidth, PetalLength, PetalWidth));
+let v3 = toscalar(Iris | where Class == "Iris-virginica" | take 1 | project pack_array(SepalLength, SepalWidth, PetalLength, PetalWidth));
 let combined = series_add(
     series_add(
         series_multiply(v1, repeat(0.5, array_length(v1))),
@@ -119,6 +195,7 @@ let combined = series_add(
     ),
     series_multiply(v3, repeat(0.2, array_length(v3)))
 );
+print combined
 ```
 
 ### Performance consideration
@@ -161,9 +238,11 @@ Vecs
 ### Point-in-polygon
 
 ```kql
-// Check if a point is inside a polygon
-| where geo_point_in_polygon(Longitude, Latitude,
-    dynamic({"type":"Polygon","coordinates":[[[lon1,lat1],[lon2,lat2],...,[lon1,lat1]]]}))
+// try it! — check if storm events occurred within a polygon around NYC
+StormEvents
+| where geo_point_in_polygon(BeginLon, BeginLat,
+    dynamic({"type":"Polygon","coordinates":[[[-74.05,40.65],[-73.85,40.65],[-73.85,40.85],[-74.05,40.85],[-74.05,40.65]]]}))
+| summarize count() by EventType
 ```
 
 Note: `geo_point_in_polygon` is a **scalar function**, not a plugin. It works on free clusters. Don't try to `evaluate` it as a plugin — use it directly in `| where` or `| extend`.
@@ -171,11 +250,17 @@ Note: `geo_point_in_polygon` is a **scalar function**, not a plugin. It works on
 ### Distance calculations
 
 ```kql
-// Distance between two points (returns meters)
-| extend distance_m = geo_distance_2points(Lon1, Lat1, Lon2, Lat2)
+// try it! — distance between start and end points of storm events (meters)
+StormEvents
+| where isnotempty(BeginLat) and isnotempty(EndLat)
+| extend distance_m = geo_distance_2points(BeginLon, BeginLat, EndLon, EndLat)
+| project EventType, State, distance_m
+| top 5 by distance_m desc
 
-// Filter by distance
-| where geo_distance_2points(Lon, Lat, -122.33, 47.61) < 5000  // within 5km of Seattle
+// Filter by distance — storms within 50km of Houston (-95.37, 29.76)
+StormEvents
+| where geo_distance_2points(BeginLon, BeginLat, -95.37, 29.76) < 50000
+| summarize count() by EventType
 ```
 
 ### Spatial bucketing for joins
@@ -183,29 +268,28 @@ Note: `geo_point_in_polygon` is a **scalar function**, not a plugin. It works on
 KQL joins are equality-only, so spatial proximity joins need pre-bucketing:
 
 ```kql
-// S2 cells (Google's spatial index)
-| extend cell = geo_point_to_s2cell(Longitude, Latitude, 8)  // level 8 ≈ 30km²
+// try it! — S2 cells on storm events
+StormEvents
+| extend cell = geo_point_to_s2cell(BeginLon, BeginLat, 8)
+| summarize count() by cell
+| top 10 by count_ desc
 
-// H3 cells (Uber's spatial index)
-| extend cell = geo_point_to_h3cell(Longitude, Latitude, 5)  // resolution 5 ≈ 253km²
-
-// Then join on cell IDs
-TableA
-| extend cell = geo_point_to_s2cell(Lon, Lat, 10)
-| join kind=inner (TableB | extend cell = geo_point_to_s2cell(Lon, Lat, 10)) on cell
+// Then join on cell IDs (e.g., storm events near taxi pickups)
+StormEvents
+| extend cell = geo_point_to_s2cell(BeginLon, BeginLat, 5)
+| join kind=inner (nyc_taxi | extend cell = geo_point_to_s2cell(pickup_longitude, pickup_latitude, 5)) on cell
+| take 10
 ```
 
 ### IP geolocation
 
 ```kql
-// Lookup IP addresses against a geo table
-| evaluate ipv4_lookup(IpGeoTable, ClientIP, IpRange)
-
-// Check if IP is in a range
-| where ipv4_is_in_range(ClientIP, "10.0.0.0/8")
-
-// Compare two IPs for subnet membership
+// try it! — check if IPs are in a range (using inline test data)
+datatable(ClientIP:string) ["10.1.2.3", "172.16.5.6", "192.168.1.1", "8.8.8.8"]
 | where ipv4_is_in_any_range(ClientIP, dynamic(["10.0.0.0/8", "172.16.0.0/12"]))
+
+// Check if an IP is in a specific subnet
+print is_private = ipv4_is_in_range("10.1.2.3", "10.0.0.0/8")
 ```
 
 ---
@@ -215,107 +299,141 @@ TableA
 ### Creating time series
 
 ```kql
-// Basic time series
-Events
-| make-series count() default=0 on Timestamp step 1h
+// try it! — basic time series from storm events
+StormEvents
+| make-series count() default=0 on StartTime step 1d
 | render timechart
 
-// Multi-series (one per category)
-Events
-| make-series count() default=0 on Timestamp step 1h by Category
+// Multi-series (one per event type)
+StormEvents
+| make-series count() default=0 on StartTime step 1d by EventType
+| take 5
 ```
 
 ### Anomaly detection
 
 ```kql
-// Decompose and find anomalies
-Events
-| make-series count() default=0 on Timestamp step 1h
+// try it! — decompose and find anomalies in daily storm counts
+StormEvents
+| make-series count() default=0 on StartTime step 1d
 | extend (anomalies, score, baseline) = series_decompose_anomalies(count_)
-| mv-expand Timestamp, count_, anomalies, score, baseline
+| mv-expand StartTime, count_, anomalies, score, baseline
 | where anomalies != 0
+| take 10
 ```
 
 ### Period detection
 
 ```kql
-// Find periodic patterns
-Events
-| make-series count() default=0 on Timestamp step 1m
-| extend (periods, scores) = series_periods_detect(count_, 4.0, 1440.0, 2)
+// try it! — find periodic patterns in occupancy sensor data
+OccupancyDetection
+| make-series avg_temp = avg(Temperature) default=0 on Timestamp step 10m
+| extend (periods, scores) = series_periods_detect(avg_temp, 4.0, 1440.0, 2)
+| project periods, scores
 ```
 
 ### Sessionization
 
 ```kql
-// Group events into sessions with 30-minute gap
-Events
-| order by UserId, Timestamp asc
-| extend SessionId = row_window_session(Timestamp, 30m, 24h, UserId != prev(UserId))
+// try it! — group trace logs into sessions with 5-minute gap
+cluster("help").database("SampleLogs").TraceLogs
+| order by Source, Timestamp asc
+| extend SessionId = row_window_session(Timestamp, 5m, 1h, Source != prev(Source))
+| summarize EventCount = count(), SessionStart = min(Timestamp) by Source, SessionId
+| take 5
 ```
 
 ### Sliding window statistics
 
 ```kql
-// Rolling average over 7 days
-| make-series val=avg(Value) on Timestamp step 1d
-| extend rolling_avg = series_fir(val, repeat(1.0/7, 7), false)
+// try it! — rolling average on occupancy temperature
+OccupancyDetection
+| make-series avg_temp = avg(Temperature) on Timestamp step 1h
+| extend rolling_avg = series_fir(avg_temp, repeat(1.0/7, 7), false)
+| take 1
 ```
 
 ---
 
 ## 5. External Data
 
-Load external files directly into KQL without ingestion:
+Load small reference tables (up to ~100 MB) directly into KQL without ingestion using the `externaldata` operator:
 
 ```kql
-// CSV from blob storage
-let external_csv = external_data(col1:string, col2:long)
-  [h@'https://storage.blob.core.windows.net/container/file.csv']
-  with (ignoreFirstRecord=true);
-external_csv | where col2 > 100
+// try it! — load Iris dataset from a public CSV on GitHub
+externaldata(SepalLength:real, SepalWidth:real, PetalLength:real, PetalWidth:real, Class:string)
+  [h@"https://raw.githubusercontent.com/uiuc-cse/data-fa14/gh-pages/data/iris.csv"]
+  with (format="csv", ignoreFirstRecord=true)
+| summarize count() by Class
+```
+
+**Notes**:
+- `externaldata` supports all [ingestion data formats](https://learn.microsoft.com/en-us/kusto/ingestion-supported-formats) (CSV, TSV, JSON, Parquet, Avro, ORC, etc.). For hierarchical formats, specify `ingestionMapping`.
+- Not designed for large data volumes — for larger datasets, use **external tables** (see below) or ingest the data into a table.
+- For non-tabular content (images, PDFs, JavaScript), use Python or the browser.
+
+### External tables for larger datasets
+
+For data too large for `externaldata` or queried repeatedly, define a persistent [external table](https://learn.microsoft.com/en-us/kusto/query/schema-entities/external-tables). External tables have a stored schema and point to data in Azure Blob Storage, ADLS, Delta Lake, or SQL databases (SQL Server, MySQL, PostgreSQL, Cosmos DB).
+
+```kql
+// Create an external table (management command)
+.create external table ExternalLogs (Timestamp:datetime, Level:string, Message:string)
+  kind=storage
+  dataformat=csv
+  (h@'https://storage.blob.core.windows.net/logs/2024/;managed_identity=system')
+  with (ignoreFirstRecord=true)
 ```
 
 ```kql
-// Gzipped CSV
-let primes = external_data(prime:long)
-  [h@'https://yourstorage.blob.core.windows.net/prime-numbers/prime-numbers.csv.gz']
-  with (ignoreFirstRecord=true);
-primes | where prime < 100000000 | summarize max(prime)
+// try it! — query the TaxiRides external table on the help cluster
+external_table("TaxiRides")
+| where pickup_datetime between (datetime(2016-01-01) .. datetime(2016-01-02))
+| summarize count() by payment_type
 ```
 
-**Limitations**: `external_data` handles tabular formats (CSV, TSV, JSON lines). For non-tabular content (images, PDFs, JavaScript), use the browser or Python.
+```kql
+// try it! — discover available external tables
+.show external tables
+```
+
+**When to use which**:
+| Approach | Best for |
+|----------|----------|
+| `externaldata` | Small reference lookups (≤100 MB), one-off queries |
+| External tables | Larger datasets, repeated queries, partitioned data, Delta Lake / SQL sources |
+| Ingested tables | Highest performance, full indexing, data you own and query frequently |
 
 ---
 
 ## 6. Stored Functions
 
-Some databases include pre-built stored functions (e.g., `Decrypt`, `Dekrypt`, `Verify`).
+Some databases include pre-built stored functions. The help cluster has several in the Samples database.
 
 ### Discovering stored functions
 
 ```kql
-// Management command — use kusto_command or kusto_list_entities(entity_type="functions")
+// Management command — use kusto_command or kusto_list_entities(entity_type="function")
 .show functions
 ```
 
 ### Invoking stored functions
 
 ```kql
-// Call a stored function
-Decrypt(ciphertext, key)
+// try it! — call a stored function with a parameter
+MyFunction2(5)
 
-// Use in a query pipeline
-Logs
-| extend plaintext = Decrypt(EncryptedField, "MYKEY")
-| where plaintext contains "suspicious"
+// try it! — use a stored function to filter a query pipeline
+StormEvents
+| where State in (InterestingStates())
+| summarize count() by State
 ```
 
 ### Common pitfalls with stored functions
 
-1. **String escaping**: KQL uses single quotes for string literals. If the key contains special characters, use `@""` syntax:
+1. **String escaping**: KQL supports both single (`'...'`) and double (`"..."`) quotes for string literals. If a string contains special characters or backslashes, use verbatim syntax `@"..."` or `@'...'`:
    ```kql
-   Decrypt(field, @"KEY'WITH'QUOTES")
+   MyCalc(1.0, 2.5, 3.7)
    ```
 2. **Argument types**: Ensure you pass the right type. If the function expects `string` and you have `dynamic`, cast with `tostring()`.
 3. **Function not found**: Check the database — functions are database-scoped. Use `.show functions` to list available ones.
@@ -329,23 +447,23 @@ Logs
 When a subquery is referenced multiple times, `materialize()` computes it once:
 
 ```kql
-let expensive_result = materialize(
-    HugeLogs
-    | where Timestamp > ago(1d)
-    | summarize count() by SourceIP
-    | where count_ > 1000
+// try it! — compute once, use twice
+let top_states = materialize(
+    StormEvents
+    | summarize EventCount = count() by State
+    | where EventCount > 1000
 );
 // Use it twice without recomputing
-expensive_result | summarize total = sum(count_)
-| union (expensive_result | top 10 by count_ desc)
+top_states | summarize TotalEvents = sum(EventCount)
+| union (top_states | top 3 by EventCount desc)
 ```
 
 ### toscalar() for single-value subqueries
 
 ```kql
-// Extract a single value to use as a constant
-let threshold = toscalar(Stats | summarize percentile(Value, 95));
-Events | where Value > threshold
+// try it! — extract a single value to use as a constant
+let avg_damage = toscalar(StormEvents | summarize avg(DamageProperty));
+StormEvents | where DamageProperty > avg_damage | summarize count()
 ```
 
 ### datatable for inline test data
@@ -360,4 +478,152 @@ let test_data = datatable(Name:string, Score:long) [
 test_data | where Score > 90
 ```
 
-Use `datatable` + `print` to test transformations on small samples before running on full tables.
+---
+
+## 8. Good Query Habits
+
+Patterns that prevent wasted time, runaway queries, and unnecessary retries.
+
+### Test transformations on small data first
+
+Use `datatable` or `print` to validate logic before running on full tables. This catches syntax errors and logic bugs without touching real data.
+
+```kql
+// Test a regex extraction before running on millions of rows
+let sample = datatable(Msg:string) [
+    "User 'alice' sent 1024 bytes",
+    "User 'bob' sent 512 bytes",
+    "Invalid line with no match"
+];
+sample
+| parse Msg with * "User '" Username "' sent " ByteCount " bytes"
+| where isnotempty(Username)
+```
+
+```kql
+// Test a datetime format with print
+print result = format_datetime(datetime(2024-03-15T10:30:00Z), "yyyy-MM")
+```
+
+### Start with count, then sample, then full query
+
+```kql
+// Step 1: How big is this table?
+StormEvents | count
+
+// Step 2: What does the data look like?
+StormEvents | take 10
+
+// Step 3: Now write the real query with filters
+StormEvents
+| where StartTime between (datetime(2007-06-01) .. datetime(2007-06-30T23:59:59))
+| summarize count() by EventType
+| top 20 by count_ desc
+```
+
+### Use materialize() to avoid redundant computation
+
+When referencing the same subquery more than once, wrap it in `materialize()` (see Section 7).
+
+### Project early, project often
+
+Drop columns you don't need as early as possible — especially wide columns like vectors, JSON blobs, or free-text fields. This reduces memory pressure and speeds up downstream operators.
+
+```kql
+// ❌ Carries all columns through the pipeline
+StormEvents | where State == "TEXAS" | summarize count() by EventType
+
+// ✅ Drop unneeded columns immediately
+StormEvents | where State == "TEXAS" | project State, EventType | summarize count() by EventType
+```
+
+### Order predicates for maximum pruning
+
+Kusto has efficient indexes on `datetime` and `string` term columns. Order your `where` predicates to exploit this:
+
+1. **`datetime` filters first** — enables shard pruning (entire data extents skipped)
+2. **`string`/`dynamic` term filters next** — `has`, `==`, `in` use the term index
+3. **Numeric filters** — less selective but still cheap
+4. **Substring scans last** — `contains`, `matches regex` must scan column data
+
+```kql
+// ❌ Substring scan runs first on all data
+StormEvents
+| where EventNarrative contains "power line"
+| where StartTime between (datetime(2007-06-01) .. datetime(2007-06-30T23:59:59))
+
+// ✅ Datetime prunes shards, then term filter, then substring
+StormEvents
+| where StartTime between (datetime(2007-06-01) .. datetime(2007-06-30T23:59:59))
+| where EventType has "Wind"
+| where EventNarrative contains "power line"
+```
+
+### Join performance hints
+
+```kql
+// hint.shufflekey — for high-cardinality join keys (>1M distinct values)
+StormEvents
+| join hint.shufflekey=EventId kind=inner (StormEvents | project EventId, State) on EventId
+
+// hint.strategy=broadcast — when left side is small (<100 MB)
+PopulationData
+| join hint.strategy=broadcast kind=inner (StormEvents) on State
+
+// Use lookup instead of join when right side is small
+StormEvents
+| lookup kind=leftouter (PopulationData) on State
+```
+
+### Use `in` instead of left semi join
+
+For filtering by a single column, `in` is simpler and often faster:
+
+```kql
+// ❌ Verbose
+StormEvents
+| join kind=leftsemi (StormEvents | where State == "TEXAS" | project State) on State
+
+// ✅ Simpler and often faster
+StormEvents
+| where State in (InterestingStates())
+```
+
+### Pre-filter dynamic columns with `has`
+
+Parsing dynamic/JSON columns is expensive. Use `has` to filter out non-matching rows before parsing:
+
+```kql
+// ❌ Parses JSON for every row
+StormEvents
+| where StormSummary.Details.Description has "tornado"
+
+// ✅ Term filter first, then parse — skips JSON parsing on non-matching rows
+StormEvents
+| where StormSummary has "tornado"
+| where StormSummary.Details.Description has "tornado"
+```
+
+### Summarize with shuffle strategy
+
+When `summarize` has high-cardinality group keys, use `hint.strategy=shuffle` to parallelize across nodes:
+
+```kql
+// ❌ Single-node bottleneck with millions of distinct keys
+StormEvents | summarize count() by EventId
+
+// ✅ Shuffle distributes work across all nodes
+StormEvents | summarize hint.strategy=shuffle count() by EventId
+```
+
+### Query materialized views efficiently
+
+Use the `materialized_view()` function to query only the pre-aggregated part (faster), rather than the full view which may include un-materialized delta records:
+
+```kql
+// try it! — queries only the materialized (pre-computed) part — fastest
+materialized_view("DailyCovid19") | take 5
+
+// Queries materialized + delta records — complete but slower
+DailyCovid19 | take 5
+```

--- a/.github/skills/kql/references/discovery-queries.md
+++ b/.github/skills/kql/references/discovery-queries.md
@@ -1,0 +1,289 @@
+# KQL Schema Discovery Queries
+
+Reference for schema exploration commands. Use these to understand a database's structure before writing queries.
+
+---
+
+## Table and Column Discovery
+
+### Table Discovery
+
+```kql
+// List all tables with row counts and sizes
+.show tables details
+| project TableName, TotalRowCount, TotalOriginalSize, TotalExtentSize, HotOriginalSize
+
+// List tables (names only)
+.show tables
+| project TableName
+
+// Table schema (column names, types, folder)
+.show table StormEvents schema as json
+
+// Table schema as CSL (for scripting)
+.show table StormEvents cslschema
+
+// Compact column listing (CSL format)
+.show table StormEvents cslschema
+| project TableName, Schema
+```
+
+### Column Statistics
+
+```kql
+// Column cardinality and statistics (sample-based)
+.show table StormEvents column statistics
+
+// Quick column profiling via query
+StormEvents
+| take 10000
+| summarize
+    Rows = count(),
+    Nulls = countif(isnull(BeginLat)),
+    Distinct = dcount(State),
+    MinVal = min(StartTime),
+    MaxVal = max(StartTime)
+```
+
+---
+
+## Function and View Discovery
+
+### Function Discovery
+
+```kql
+// List all stored functions
+.show functions
+| project Name, Parameters, Body = substring(Body, 0, 100), DocString, Folder
+
+// Full function definition
+.show function MyFunction2
+
+// Functions in a folder
+.show functions
+| where Folder == "Demo"
+```
+
+### Materialized View Discovery
+
+```kql
+// List all materialized views
+.show materialized-views
+| project Name, SourceTable, Query = substring(Query, 0, 100), IsEnabled, IsHealthy
+
+// View statistics (lag, processed records)
+.show materialized-view DailyCovid19 statistics
+
+// View extents
+.show materialized-view DailyCovid19 extents
+| summarize ExtentCount = count(), TotalRows = sum(RowCount)
+```
+
+---
+
+## Policy Discovery
+
+```kql
+// Retention policies
+.show table StormEvents policy retention
+
+// Caching policies
+.show table StormEvents policy caching
+
+// Streaming ingestion policy
+.show table StormEvents policy streamingingestion
+
+// Update policies
+.show table StormEvents policy update
+
+// All major policies for a table (run individually):
+// retention, caching, streamingingestion, update, merge, sharding
+```
+
+---
+
+## External Tables and Ingestion Mappings
+
+### External Table Discovery
+
+```kql
+// List external tables
+.show external tables
+| project TableName, TableType, Folder, ConnectionStrings
+
+// External table schema
+.show external table TaxiRides schema as json
+```
+
+### Ingestion Mapping Discovery
+
+```kql
+// CSV mappings for a table
+.show table StormEvents ingestion csv mappings
+
+// JSON mappings for a table
+.show table StormEvents ingestion json mappings
+
+// All mappings for a table
+.show table StormEvents ingestion mappings
+```
+
+---
+
+## Graph Model Discovery
+
+```kql
+// List all graph models
+.show graph_models
+
+// Show a specific graph model definition
+.show graph_model Simple
+
+// List graph snapshots
+.show graph_snapshots
+```
+
+---
+
+## Security Discovery
+
+```kql
+// Database-level principals
+.show database Samples principals
+
+// Table-level principals
+.show table StormEvents principals
+
+// Current identity
+print CurrentUser = current_principal(), Cluster = current_cluster_endpoint()
+```
+
+---
+
+## Database Overview Script
+
+Run this sequence to get a complete picture of a KQL Database:
+
+```kql
+// 1. Database stats (uses current database context)
+.show database datastats
+
+// 2. All tables with details
+.show tables details
+| project TableName, TotalRowCount, TotalOriginalSize, CachingPolicy
+| order by TotalRowCount desc
+
+// 3. All functions
+.show functions
+| project Name, Folder, DocString, Parameters
+
+// 4. All materialized views
+.show materialized-views
+| project Name, SourceTable, IsEnabled, IsHealthy
+
+// 5. All external tables
+.show external tables
+
+// 6. All graph models
+.show graph_models
+```
+
+---
+
+## Advanced Troubleshooting
+
+Commands for diagnosing ingestion failures, throttling, capacity issues, and cluster health.
+
+### Ingestion Failures
+
+When data isn't showing up after ingestion, check for failures (retained for 14 days):
+
+```kql
+// Show all recent ingestion failures
+.show ingestion failures
+
+// Filter to a specific table
+.show ingestion failures
+| where Table == "StormEvents"
+| where FailedOn > ago(1d)
+| project FailedOn, Table, FailureKind, ErrorCode, Details
+| order by FailedOn desc
+
+// Check a specific operation
+.show ingestion failures with (OperationId = 'GUID-HERE')
+```
+
+Key columns: `FailureKind` (Permanent vs Transient), `ErrorCode`, `Details`, `OriginatesFromUpdatePolicy`.
+
+### Cluster Capacity
+
+Check whether the cluster is running out of capacity for ingestion, merges, exports, or other operations:
+
+```kql
+// Show capacity for all resource types
+.show capacity
+
+// Show capacity for a specific operation
+.show capacity ingestions
+.show capacity extents-merge
+.show capacity data-export
+.show capacity materialized-view
+.show capacity extents-partition
+```
+
+Returns `Total`, `Consumed`, and `Remaining` for each resource. If `Remaining` is 0, operations are being throttled.
+
+### Cluster Diagnostics
+
+```kql
+// Cluster health and node state
+.show diagnostics
+
+// Currently running queries (useful for identifying long-running or stuck queries)
+.show queries
+
+// Completed commands and their resource usage
+.show commands
+| where StartedOn > ago(1h)
+| project CommandType, StartedOn, Duration, State, ResourceUtilization
+
+// Combined view of commands and queries
+.show commands-and-queries
+| where StartedOn > ago(1h)
+| order by StartedOn desc
+
+// Administrative operations log
+.show operations
+| where StartedOn > ago(1d)
+| where State == "Failed"
+```
+
+### Workload Groups
+
+Workload groups control resource governance — per-request limits, rate limits, and concurrency. If queries are being throttled or rejected, check workload group configuration:
+
+```kql
+// Show all workload groups and their policies
+.show workload_group default
+
+// Monitor requests by workload group
+.show commands-and-queries
+| where StartedOn > ago(1h)
+| summarize count(), avg(Duration), sum(TotalCPU) by WorkloadGroup
+```
+
+Built-in workload groups:
+- **`default`** — catches all requests not classified elsewhere
+- **`internal`** — internal system requests (cannot be modified)
+- **`$materialized-views`** — materialized view materialization process
+
+### Troubleshooting Decision Tree
+
+| Symptom | First command | What to look for |
+|---------|--------------|------------------|
+| Data not appearing after ingestion | `.show ingestion failures` | `FailureKind`, `ErrorCode`, `Details` |
+| Queries running slowly or timing out | `.show capacity` | `Remaining` = 0 on any resource |
+| Queries being rejected/throttled | `.show workload_group default` | Rate limits, concurrent request caps |
+| Cluster unresponsive | `.show diagnostics` | Node health, memory pressure |
+| Merges falling behind | `.show capacity extents-merge` | `Remaining` = 0 |
+| Materialized views stale | `.show materialized-view DailyCovid19 statistics` | Materialization lag |

--- a/.github/skills/kql/references/error-recovery.md
+++ b/.github/skills/kql/references/error-recovery.md
@@ -26,41 +26,41 @@ Complete mapping of common KQL error patterns. For each error: the exact message
 ### Pattern A: Unfiltered aggregation on large table
 
 ```kql
-// ❌ TRIGGERED ERROR — 24M rows, no pre-filter
-Consumption
-| summarize dcount(Consumed), count() by Timestamp, HouseholdId, MeterType
-| where dcount_Consumed > 1
+// ❌ TRIGGERED ERROR — large table, no pre-filter, too many group-by columns
+StormEvents
+| summarize dcount(EventType), count() by StartTime, State, Source
+| where dcount_EventType > 1
 
 // ✅ FIX — filter first, reduce grouping columns
-Consumption
-| where Timestamp between (datetime(2023-04-15) .. datetime(2023-04-16))
-| summarize dcount(Consumed) by HouseholdId, MeterType
-| where dcount_Consumed > 1
+StormEvents
+| where StartTime between (datetime(2007-04-15) .. datetime(2007-04-16))
+| summarize dcount(EventType) by State, Source
+| where dcount_EventType > 1
 ```
 
 ### Pattern B: Join explosion
 
 ```kql
-// ❌ TRIGGERED ERROR — 25K IPs × 195 polygons
-ip_locations
-| join kind=inner (Cities | where HackersCount >= 256) on $left.CityName == $right.CityName
+// ❌ TRIGGERED ERROR — unconstrained join between two large tables
+StormEvents
+| join kind=inner (PopulationData) on State
 
 // ✅ FIX — pre-filter both sides, check cardinality first
-let filtered_ips = ip_locations | where CountryCode == "US" | summarize by CityName;
-let target_cities = Cities | where HackersCount >= 256 | project CityName;
-filtered_ips | join kind=inner target_cities on CityName
+let filtered_storms = StormEvents | where State == "TEXAS" | summarize by State;
+let target_states = PopulationData | project State;
+filtered_storms | join kind=inner (target_states) on State
 ```
 
 ### Pattern C: High-cardinality dcount()
 
 ```kql
-// ❌ TRIGGERED ERROR — Full distinct value enumeration
-Logs | summarize dcount(SourceIP), dcount(DestIP), dcount(Port) by bin(Timestamp, 1h)
+// ❌ TRIGGERED ERROR — Full distinct value enumeration on many columns
+StormEvents | summarize dcount(EventType), dcount(Source), dcount(BeginLocation) by bin(StartTime, 1h)
 
-// ✅ FIX — use approximate counts or filter first
-Logs
-| where Timestamp > ago(1d)
-| summarize dcount(SourceIP) by bin(Timestamp, 1h)
+// ✅ FIX — filter first, reduce to one dcount
+StormEvents
+| where StartTime between (datetime(2007-06-01) .. datetime(2007-06-30T23:59:59))
+| summarize dcount(EventType) by bin(StartTime, 1h)
 ```
 
 **Recovery strategy**: When you see this error, your query is touching too much data. Options:
@@ -79,19 +79,19 @@ Logs
 
 ```kql
 // ❌ TRIGGERED ERROR — incomplete on clause
-TableA | join kind=inner TableB on $left.Id
+StormEvents | join kind=inner PopulationData on $left.State
 
 // ✅ FIX — specify both sides
-TableA | join kind=inner TableB on $left.Id == $right.Id
+StormEvents | join kind=inner (PopulationData) on $left.State == $right.State
 ```
 
 ```kql
 // ❌ TRIGGERED ERROR — expression in join condition
-TableA | join kind=inner TableB on $left.Id == $right.tolower(Name)
+StormEvents | join kind=inner (PopulationData) on $left.State == $right.tolower(State)
 
 // ✅ FIX — pre-compute the expression, join on the computed column
-TableA
-| join kind=inner (TableB | extend NameLower = tolower(Name)) on $left.Id == $right.NameLower
+StormEvents
+| join kind=inner (PopulationData | extend StateLower = tolower(State)) on $left.State == $right.StateLower
 ```
 
 ### 2b. Equality only
@@ -100,24 +100,24 @@ TableA
 
 ```kql
 // ❌ TRIGGERED ERROR — geo-distance in join predicate
-TableA | join TableB on geo_distance_2points(a.Lat, a.Lon, b.Lat, b.Lon) < 1000
+StormEvents | join (nyc_taxi) on geo_distance_2points(BeginLon, BeginLat, pickup_longitude, pickup_latitude) < 1000
 
 // ✅ FIX — pre-bucket into spatial cells
-TableA
-| extend cell = geo_point_to_s2cell(Lon, Lat, 8)
-| join kind=inner (TableB | extend cell = geo_point_to_s2cell(Lon, Lat, 8)) on cell
-| where geo_distance_2points(Lat, Lon, Lat1, Lon1) < 1000  // post-filter for precision
+StormEvents
+| extend cell = geo_point_to_s2cell(BeginLon, BeginLat, 8)
+| join kind=inner (nyc_taxi | extend cell = geo_point_to_s2cell(pickup_longitude, pickup_latitude, 8)) on cell
+| where geo_distance_2points(BeginLat, BeginLon, pickup_latitude, pickup_longitude) < 1000
 ```
 
 ```kql
 // ❌ TRIGGERED ERROR — range join
-Sales | join Thresholds on $left.Amount > $right.MinAmount
+StormEvents | join (PopulationData) on $left.DamageProperty > $right.Population
 
 // ✅ FIX — bin values and join on bins
-Sales
-| extend amount_bin = bin(Amount, 100)
-| join kind=inner (Thresholds | extend amount_bin = bin(MinAmount, 100)) on amount_bin
-| where Amount > MinAmount  // post-filter
+StormEvents
+| extend damage_bin = bin(DamageProperty, 1000000)
+| join kind=inner (PopulationData | extend damage_bin = bin(Population, 1000000)) on damage_bin
+| where DamageProperty > Population
 ```
 
 ---
@@ -130,7 +130,7 @@ Cause: Corrupted cluster URIs or genuine network timeouts.
 
 **Recovery strategy**: 
 1. Verify the cluster URI is clean ASCII (no Unicode characters)
-2. Retry with a fresh URI
+2. Retry with a fresh URI from the environment variable
 3. If persistent, wait 30 seconds and retry (cluster may be overloaded)
 
 ---
@@ -201,13 +201,14 @@ Cause: Corrupted cluster URIs or genuine network timeouts.
 
 **Error message**: `Unexpected control command`
 
-```kql
-// ❌ — .show is a management command, don't pipe query operators onto it
-.show tables | project TableName
+This error occurs when a query pipes INTO a management command (not the other way around — management commands CAN have query operators piped after them). With Fabric RTI MCP, use `kusto_command` for management commands and `kusto_query` for queries.
 
-// ✅ — use kusto_command for management commands, kusto_query for queries
-// Step 1: kusto_command(command=".show tables", ...)
-// Step 2: kusto_query(query="TableName | take 5", ...)
+```kql
+// ✅ WORKS — management output is tabular, can be filtered
+.show tables | project TableName | where TableName has "Events"
+
+// ❌ ERROR — query piped into management command
+StormEvents | take 5 | .show tables
 ```
 
 ### 6b. Reserved words as identifiers
@@ -246,14 +247,14 @@ Despite both sides being strings, KQL sometimes requires explicit casts for comp
 
 ```kql
 // ❌ — S2 cell comparison
-Runs
-| extend startCell = geo_point_to_s2cell(StartLon, StartLat, 16)
-| join kind=inner (...) on startCell
+StormEvents
+| extend startCell = geo_point_to_s2cell(BeginLon, BeginLat, 16)
+| join kind=inner (nyc_taxi | extend startCell = geo_point_to_s2cell(pickup_longitude, pickup_latitude, 16)) on startCell
 
 // ✅ — explicit tostring()
-Runs
-| extend startCell = tostring(geo_point_to_s2cell(StartLon, StartLat, 16))
-| join kind=inner (... | extend startCell = tostring(geo_point_to_s2cell(Lon, Lat, 16))) on startCell
+StormEvents
+| extend startCell = tostring(geo_point_to_s2cell(BeginLon, BeginLat, 16))
+| join kind=inner (nyc_taxi | extend startCell = tostring(geo_point_to_s2cell(pickup_longitude, pickup_latitude, 16))) on startCell
 ```
 
 This occurs most often with `geo_point_to_s2cell()`, `hash()`, and `strcat()` return values.
@@ -266,10 +267,10 @@ This occurs most often with `geo_point_to_s2cell()`, `hash()`, and `strcat()` re
 
 ```kql
 // ❌ — Missing capturing group
-| extend words = extract_all(@"[a-zA-Z]{3,}", tolower(Title))
+StormEvents | extend words = extract_all(@"[a-zA-Z]{3,}", tolower(EventNarrative))
 
 // ✅ — Add parentheses
-| extend words = extract_all(@"([a-zA-Z]{3,})", tolower(Title))
+StormEvents | extend words = extract_all(@"([a-zA-Z]{3,})", tolower(EventNarrative))
 ```
 
 Unlike Python's `re.findall()`, KQL's `extract_all` requires at least one `()` group.
@@ -282,15 +283,17 @@ Unlike Python's `re.findall()`, KQL's `extract_all` requires at least one `()` g
 
 ```kql
 // ❌
-ChatServerLogs
-| summarize Online = sum(Direction) by bin(Timestamp, 5m)
-| extend CumulativeOnline = row_cumsum(Online)
+StormEvents
+| where State == "TEXAS"
+| summarize DailyCount = count() by bin(StartTime, 1d)
+| extend CumulativeCount = row_cumsum(DailyCount)
 
 // ✅ — add order by (implicitly serializes)
-ChatServerLogs
-| summarize Online = sum(Direction) by bin(Timestamp, 5m)
-| order by Timestamp asc
-| extend CumulativeOnline = row_cumsum(Online)
+StormEvents
+| where State == "TEXAS"
+| summarize DailyCount = count() by bin(StartTime, 1d)
+| order by StartTime asc
+| extend CumulativeCount = row_cumsum(DailyCount)
 ```
 
 Affected functions: `row_number()`, `row_cumsum()`, `prev()`, `next()`, `row_window_session()`.
@@ -308,7 +311,7 @@ Some KQL functions are plugins that may not be enabled on free-tier clusters.
 | Plugin | Status on free cluster | Alternative |
 |--------|----------------------|-------------|
 | `geo_point_in_polygon` (as plugin) | ❌ Not available | Use as scalar function: `geo_point_in_polygon(lon, lat, polygon)` |
-| `python` | ❌ Not available | Use local Python instead |
+| `python` | ❌ Not available | Use powershell tool to run Python locally |
 
 ---
 
@@ -321,10 +324,17 @@ Some KQL functions are plugins that may not be enabled on free-tier clusters.
 graph-match (src)-[path*1..3]->(dst)
   where path.IsVulnerable == true
 
-// ✅ — filter edges at definition, not traversal
+// ✅ — filter edges before building the graph
 let edges = Edges | where IsVulnerable == true;
-graph(Nodes, edges)
+edges
+| make-graph SourceId --> TargetId with Nodes on NodeId
 | graph-match (src)-[path*1..3]->(dst)
+  project src.Name, dst.Name
+
+// ✅ — or use label-based filtering on persistent graphs
+graph("MyGraph")
+| graph-match (src)-[path*1..3]->(dst)
+  where all(path, labels() has "Vulnerable")
   project src.Name, dst.Name
 ```
 
@@ -337,13 +347,17 @@ The fix is to pre-filter edges before graph construction.
 **Error message**: `Runaway query (E_RUNAWAY_QUERY): Join output block exceeded memory budget`
 
 ```kql
-// ❌ — 25K × 195 unconstrained cross-join
-ip_locs | join kind=inner (Cities | where EstimatedHackersCount >= 256) on ...
+// ❌ — unconstrained cross-join on large tables
+StormEvents | join kind=inner (nyc_taxi) on $left.EventId == $right.passenger_count
 
 // ✅ — check cardinality first, pre-filter aggressively
-// Step 1: ip_locs | summarize dcount(JoinKey)  → if >10K, add filters
-// Step 2: Cities | where EstimatedHackersCount >= 256 | count  → if >100, narrow criteria
-// Step 3: Then join
+// Step 1: StormEvents | summarize dcount(State)  → 67 — OK
+// Step 2: PopulationData | count  → check if manageable
+// Step 3: Pre-filter, then join
+StormEvents
+| where State in ("NEW YORK", "TEXAS")
+| join kind=inner (PopulationData) on State
+| take 5 | project State, EventType, Population
 ```
 
 **Prevention**: Always `dcount()` both join sides before executing. If left × right > 1M, add filters.

--- a/.github/skills/kql/references/query-templates.md
+++ b/.github/skills/kql/references/query-templates.md
@@ -254,8 +254,6 @@ Table
 
 **Never skip to a complex query without running Steps 1-2 first.** Knowing the table size prevents memory errors; seeing sample rows prevents wrong assumptions about column values.
 
-**With MCP tools**: Use `kusto_sample_entity` for Step 2 and `kusto_describe_database_entity` to understand the schema before querying.
-
 ---
 
 ## 9. Diffing & Anomaly Detection


### PR DESCRIPTION
## Summary

Applies the same verified KQL skill fixes from microsoft/skills#259 to the KQL skill in this repo, **preserving all MCP-specific content**.

### What's preserved (not changed)
- **Section 1**: MCP tools table, usage examples, exploration workflow
- **Section 15**: Diagnostics and Query Optimization (kusto_show_queryplan, kusto_diagnostics)
- All MCP tool references throughout (kusto_query, kusto_command, kusto_graph_query, etc.)
- Checklist items 10-12 (MCP-specific)

### Fixes applied
- `graph(nodes, edges)` -> `make-graph` (transient) + `graph("ModelName")` (persistent)
- `external_data` -> `externaldata` (correct operator name)
- `replace_regex` parameter order fixed
- `bin()` description: rounds down, not to nearest
- `between` date ranges: inclusive end bound fix
- `hash()` removed from string comparison section
- `summarize by expression`: reframed as readability preference
- Time series example: added missing source table
- Naming conventions subsection added
- Help cluster reference note added

### New content
- `references/discovery-queries.md` - schema exploration + troubleshooting
- Section 8: Good Query Habits in advanced-patterns.md
- External tables subsection
- Real help cluster examples throughout

All fixes verified against `https://help.kusto.windows.net`.
