### PR TITLE
fix: replace Starlette @app.middleware with BaseHTTPMiddleware

### DIFF
--- a/fabric_rti_mcp/authentication/auth_middleware.py
+++ b/fabric_rti_mcp/authentication/auth_middleware.py
@@ -2,14 +2,15 @@ from __future__ import annotations
 
 import base64
 import json
-from collections.abc import Awaitable, Callable
 from typing import Any
 
 from mcp.server.fastmcp import FastMCP
 from starlette.applications import Starlette
+from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.middleware.cors import CORSMiddleware
 from starlette.requests import Request
 from starlette.responses import JSONResponse
+from starlette.types import ASGIApp
 
 from fabric_rti_mcp.authentication.token_obo_exchanger import TokenOboExchanger
 from fabric_rti_mcp.config import global_config as config
@@ -72,6 +73,86 @@ def decode_jwt_token(token: str) -> dict[str, Any]:
         return {}  # TBD : Handle token validation errors errors when validation is added
 
 
+class AuthMiddleware(BaseHTTPMiddleware):
+    """HTTP middleware that validates authorization tokens for MCP endpoints."""
+
+    def __init__(self, app: ASGIApp) -> None:
+        super().__init__(app)
+
+    async def dispatch(self, request: Request, call_next: Any) -> Any:
+        try:
+            # Skip auth check for health endpoint
+            if request.url.path == "/health":
+                return await call_next(request)
+
+            # Skip auth check for OPTIONS requests (preflight)
+            if request.method == "OPTIONS":
+                return await call_next(request)
+
+            # Check for Authorization header
+            auth_header = request.headers.get("Authorization", "") or request.headers.get("authorization", "")
+
+            if not auth_header:
+                return JSONResponse(
+                    {"error": "unauthorized", "message": "Authorization header required"}, status_code=401
+                )
+
+            request_uri = str(request.url) if "url" in request else ""
+            request_method = request.method if "method" in request else "GET"
+            logger.info(f"Request URI: {request_uri}, Method: {request_method}")
+
+            token = extract_token_from_header(auth_header)
+
+            try:
+                if config.use_obo_flow:
+                    logger.info("Started performing OBO token exchange")
+                    # Create token exchanger and perform OBO token exchange
+                    token_exchanger = TokenOboExchanger()
+                    exchanged_token = await token_exchanger.perform_obo_token_exchange(
+                        user_token=token, resource_uri=obo_config.kusto_audience
+                    )
+                    # Update token to use the exchanged token
+                    token = exchanged_token
+                    logger.info("Successfully performed OBO token exchange")
+                else:
+                    logger.info("OBO flow not enabled; using original token")
+
+            except Exception as e:
+                # Log the error and raise it to fail the request
+                logger.error(f"Error during OBO token exchange: {e}")
+                return JSONResponse(
+                    {
+                        "error": "unauthorized",
+                        "message": "Unauthorized to get the required token to access the resource",
+                    },
+                    status_code=401,
+                )
+
+            # Store the token for use by services
+            set_auth_token(token)
+
+            token_payload = decode_jwt_token(token)
+
+            audience = token_payload.get("aud", "N/A")
+            tenant_id = token_payload.get("tid", "N/A")
+            scopes = token_payload.get("scp", token_payload.get("roles", "N/A"))
+
+            logger.info(f"Token audience: {audience}")
+            logger.info(f"Token tenant ID: {tenant_id}")
+            logger.info(f"Token scopes/roles: {scopes}")
+
+            # Continue with request
+            response = await call_next(request)
+
+            logger.info(f"Response status code: {response.status_code}")
+
+            return response
+
+        except Exception as e:
+            logger.error(f"Error in auth middleware: {e}")
+            return JSONResponse({"error": "server_error", "message": "Internal server error"}, status_code=500)
+
+
 def add_auth_middleware(fastmcp: FastMCP) -> None:
     """
     Add HTTP authorization middleware by overriding streamable_http_app method.
@@ -99,79 +180,7 @@ def add_auth_middleware(fastmcp: FastMCP) -> None:
         )
 
         # Add middleware to check authentication for MCP endpoints
-        @app.middleware("http")  # type: ignore
-        async def check_auth(request: Request, call_next: Callable[[Request], Awaitable[JSONResponse]]) -> JSONResponse:  # noqa: F811  # type: ignore[reportUnusedFunction]
-            try:
-                # Skip auth check for health endpoint
-                if request.url.path == "/health":
-                    return await call_next(request)
-
-                # Skip auth check for OPTIONS requests (preflight)
-                if request.method == "OPTIONS":
-                    return await call_next(request)
-
-                # Check for Authorization header
-                auth_header = request.headers.get("Authorization", "") or request.headers.get("authorization", "")
-
-                if not auth_header:
-                    return JSONResponse(
-                        {"error": "unauthorized", "message": "Authorization header required"}, status_code=401
-                    )
-
-                request_uri = str(request.url) if "url" in request else ""
-                request_method = request.method if "method" in request else "GET"
-                logger.info(f"Request URI: {request_uri}, Method: {request_method}")
-
-                token = extract_token_from_header(auth_header)
-
-                try:
-                    if config.use_obo_flow:
-                        logger.info("Started performing OBO token exchange")
-                        # Create token exchanger and perform OBO token exchange
-                        token_exchanger = TokenOboExchanger()
-                        exchanged_token = await token_exchanger.perform_obo_token_exchange(
-                            user_token=token, resource_uri=obo_config.kusto_audience
-                        )
-                        # Update token to use the exchanged token
-                        token = exchanged_token
-                        logger.info("Successfully performed OBO token exchange")
-                    else:
-                        logger.info("OBO flow not enabled; using original token")
-
-                except Exception as e:
-                    # Log the error and raise it to fail the request
-                    logger.error(f"Error during OBO token exchange: {e}")
-                    return JSONResponse(
-                        {
-                            "error": "unauthorized",
-                            "message": "Unauthorized to get the required token to access the resource",
-                        },
-                        status_code=401,
-                    )
-
-                # Store the token for use by services
-                set_auth_token(token)
-
-                token_payload = decode_jwt_token(token)
-
-                audience = token_payload.get("aud", "N/A")
-                tenant_id = token_payload.get("tid", "N/A")
-                scopes = token_payload.get("scp", token_payload.get("roles", "N/A"))
-
-                logger.info(f"Token audience: {audience}")
-                logger.info(f"Token tenant ID: {tenant_id}")
-                logger.info(f"Token scopes/roles: {scopes}")
-
-                # Continue with request
-                response = await call_next(request)
-
-                logger.info(f"Response status code: {response.status_code}")
-
-                return response
-
-            except Exception as e:
-                logger.error(f"Error in auth middleware: {e}")
-                return JSONResponse({"error": "server_error", "message": "Internal server error"}, status_code=500)
+        app.add_middleware(AuthMiddleware)  # ty: ignore[invalid-argument-type]
 
         return app
 


### PR DESCRIPTION
Fixes a crash on startup when `FABRIC_RTI_TRANSPORT=http`

Before
```
KUSTO_SERVICE_URI=https://help.kusto.windows.net/ KUSTO_SERVICE_DEFAULT_DB=Samples FABRIC_API_BASE_URL=https://api.fabric.microsoft.com/v1 FABRIC_RTI_TRANSPORT=http uvx microsoft-fabric-rti-mcp                                                                                             
Installed 86 packages in 240ms
[04/18/26 06:25:43] INFO     Kusto configuration keys found in environment:                                                                                                 server.py:37
                    INFO     KUSTO_SERVICE_URI, KUSTO_SERVICE_DEFAULT_DB                                                                                                    server.py:38
                    INFO     Adding authorization middleware                                                                                                               server.py:119
                    INFO     Starting fabric-rti-mcp-server (HTTP) on 127.0.0.1:3000 with /health endpoint                                                                 server.py:126
                    ERROR    Server error: 'Starlette' object has no attribute 'middleware'                                                                                server.py:135
Traceback (most recent call last):
  File "/home/node/.cache/uv/archive-v0/nxUr0tgC-Kgi31SDp-8Ip/bin/microsoft-fabric-rti-mcp", line 12, in <module>
    sys.exit(main())
             ~~~~^^
  File "/home/node/.cache/uv/archive-v0/nxUr0tgC-Kgi31SDp-8Ip/lib/python3.13/site-packages/fabric_rti_mcp/server.py", line 127, in main
    fastmcp_server.run(transport="streamable-http")
    ~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/node/.cache/uv/archive-v0/nxUr0tgC-Kgi31SDp-8Ip/lib/python3.13/site-packages/mcp/server/fastmcp/server.py", line 300, in run
    anyio.run(self.run_streamable_http_async)
    ~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/node/.cache/uv/archive-v0/nxUr0tgC-Kgi31SDp-8Ip/lib/python3.13/site-packages/anyio/_core/_eventloop.py", line 77, in run
    return async_backend.run(func, args, {}, backend_options)
           ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/node/.cache/uv/archive-v0/nxUr0tgC-Kgi31SDp-8Ip/lib/python3.13/site-packages/anyio/_backends/_asyncio.py", line 2358, in run
    return runner.run(wrapper())
           ~~~~~~~~~~^^^^^^^^^^^
  File "/usr/lib/python3.13/asyncio/runners.py", line 118, in run
    return self._loop.run_until_complete(task)
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^
  File "/usr/lib/python3.13/asyncio/base_events.py", line 725, in run_until_complete
    return future.result()
           ~~~~~~~~~~~~~^^
  File "/home/node/.cache/uv/archive-v0/nxUr0tgC-Kgi31SDp-8Ip/lib/python3.13/site-packages/anyio/_backends/_asyncio.py", line 2341, in wrapper
    return await func(*args)
           ^^^^^^^^^^^^^^^^^
  File "/home/node/.cache/uv/archive-v0/nxUr0tgC-Kgi31SDp-8Ip/lib/python3.13/site-packages/mcp/server/fastmcp/server.py", line 781, in run_streamable_http_async
    starlette_app = self.streamable_http_app()
  File "/home/node/.cache/uv/archive-v0/nxUr0tgC-Kgi31SDp-8Ip/lib/python3.13/site-packages/fabric_rti_mcp/authentication/auth_middleware.py", line 102, in auth_required_streamable_app
    @app.middleware("http")  # type: ignore
     ^^^^^^^^^^^^^^
AttributeError: 'Starlette' object has no attribute 'middleware'. Did you mean: 'add_middleware'?
```

After
```
KUSTO_SERVICE_URI=https://help.kusto.windows.net/ KUSTO_SERVICE_DEFAULT_DB=Samples FABRIC_API_BASE_URL=https://api.fabric.microsoft.com/v1 FABRIC_RTI_TRANSPORT=http uvx --from git+https://github.com/pl4nty/fabric-rti-mcp microsoft-fabric-rti-mcp           
    Updated https://github.com/pl4nty/fabric-rti-mcp (d85b99260041022fe14f2159354975598634e250)
      Built microsoft-fabric-rti-mcp @ git+https://github.com/pl4nty/fabric-rti-mcp@d85b99260041022fe14f2159354975598634e250
Installed 86 packages in 152ms
[04/18/26 06:28:50] INFO     Kusto configuration keys found in environment:                                                                                                 server.py:37
                    INFO     KUSTO_SERVICE_URI, KUSTO_SERVICE_DEFAULT_DB                                                                                                    server.py:38
                    INFO     Adding authorization middleware                                                                                                               server.py:119
                    INFO     Starting fabric-rti-mcp-server (HTTP) on 127.0.0.1:3000 with /health endpoint                                                                 server.py:126
INFO:     Started server process [35407]
INFO:     Waiting for application startup.
[04/18/26 06:28:51] INFO     StreamableHTTP session manager started                                                                                       streamable_http_manager.py:128
INFO:     Application startup complete.
INFO:     Uvicorn running on http://127.0.0.1:3000 (Press CTRL+C to quit)
```