### PR TITLE
Fix Kusto live tests

### DIFF
--- a/.github/workflows/live-tests.yml
+++ b/.github/workflows/live-tests.yml
@@ -1,0 +1,59 @@
+name: Live Tests
+
+on:
+  workflow_dispatch:
+    inputs:
+      cluster_uri:
+        description: Kusto cluster URI used by the read-only live tests.
+        required: true
+        default: https://help.kusto.windows.net
+      database:
+        description: Kusto database used by the read-only live tests.
+        required: true
+        default: Samples
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  kusto-live-tests:
+    name: Kusto live tests
+    runs-on: ubuntu-latest
+    environment: live-tests
+
+    env:
+      KUSTO_LIVE_CLUSTER_URI: ${{ inputs.cluster_uri }}
+      KUSTO_LIVE_DATABASE: ${{ inputs.database }}
+      KUSTO_SERVICE_URI: ${{ inputs.cluster_uri }}
+      KUSTO_SERVICE_DEFAULT_DB: ${{ inputs.database }}
+      KUSTO_ALLOW_UNKNOWN_SERVICES: "false"
+      KUSTO_EAGER_CONNECT: "false"
+      FABRIC_RTI_KUSTO_RESPONSE_FORMAT: kusto_response
+      FABRIC_RTI_KUSTO_DEEPLINK_STYLE: adx
+      FABRIC_RTI_AI_FOUNDRY_COMPATIBILITY_SCHEMA: "false"
+      FABRIC_RTI_TRANSPORT: stdio
+      USE_OBO_FLOW: "false"
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - name: Azure login with OIDC
+        uses: azure/login@v2
+        with:
+          client-id: ${{ vars.AZURE_CLIENT_ID }}
+          tenant-id: ${{ vars.AZURE_TENANT_ID }}
+          allow-no-subscriptions: true
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e ".[dev]"
+
+      - name: Run Kusto live tests
+        run: python -m tests.live.test_kusto_tools_live

--- a/tests/live/test_kusto_tools_live.py
+++ b/tests/live/test_kusto_tools_live.py
@@ -8,6 +8,7 @@ import os
 import sys
 from datetime import datetime, timedelta, timezone
 from typing import Any
+from urllib.parse import urlparse
 
 from fabric_rti_mcp.services.kusto.kusto_formatter import KustoFormatter
 
@@ -18,6 +19,23 @@ try:
 except ImportError:
     print("MCP client dependencies not available. Install with: pip install mcp")
     sys.exit(1)
+
+
+EXPECTED_KUSTO_TOOLS = [
+    "kusto_known_services",
+    "kusto_query",
+    "kusto_command",
+    "kusto_list_entities",
+    "kusto_describe_database",
+    "kusto_describe_database_entity",
+    "kusto_graph_query",
+    "kusto_sample_entity",
+    "kusto_ingest_inline_into_table",
+    "kusto_get_shots",
+    "kusto_deeplink_from_query",
+    "kusto_show_queryplan",
+    "kusto_diagnostics",
+]
 
 
 class McpClient:
@@ -92,6 +110,13 @@ class McpClient:
             raise RuntimeError(f"No active MCP session for server: {self.server_name}")
 
         result = await self.session.call_tool(tool_name, arguments=arguments)
+
+        if getattr(result, "isError", False) or getattr(result, "is_error", False):
+            error_parts = []
+            for content_item in result.content or []:
+                if isinstance(content_item, TextContent):
+                    error_parts.append(content_item.text)
+            return {"success": False, "error": "\n".join(error_parts) or "Tool returned an error"}
 
         # First, check if there's structured content (preferred)
         if hasattr(result, "structuredContent") and result.structuredContent:
@@ -175,7 +200,16 @@ class KustoToolsLiveTester:
             }
         ]
         env["KUSTO_KNOWN_SERVICES"] = json.dumps(test_services)
-        env["KUSTO_ALLOW_UNKNOWN_SERVICES"] = "true"
+        env["KUSTO_SERVICE_URI"] = self.test_cluster_uri
+        env["KUSTO_SERVICE_DEFAULT_DB"] = self.test_database
+        env["KUSTO_ALLOW_UNKNOWN_SERVICES"] = "false"
+        env["KUSTO_EAGER_CONNECT"] = "false"
+        env["FABRIC_RTI_TRANSPORT"] = "stdio"
+        env["FABRIC_RTI_AI_FOUNDRY_COMPATIBILITY_SCHEMA"] = "false"
+        env["FABRIC_RTI_KUSTO_DEEPLINK_STYLE"] = "adx"
+        env["FABRIC_RTI_KUSTO_RESPONSE_FORMAT"] = "kusto_response"
+        env["USE_OBO_FLOW"] = "false"
+        env.pop("PORT", None)
 
         self.client = McpClient("fabric-rti-mcp-server", command, env)
         await self.client.connect()
@@ -186,6 +220,29 @@ class KustoToolsLiveTester:
         if self.client:
             await self.client.disconnect()
             print("✅ Disconnected from MCP server")
+
+    @staticmethod
+    def _payload(result: dict[str, Any]) -> Any:
+        if "result" in result:
+            return result["result"]
+        return {key: value for key, value in result.items() if key != "success"}
+
+    @staticmethod
+    def _parse_kusto_datetime(value: str) -> datetime:
+        normalized = value.replace("Z", "+00:00")
+        if "." not in normalized:
+            return datetime.fromisoformat(normalized)
+
+        timestamp_part, fractional_part = normalized.split(".", 1)
+        timezone_start = len(fractional_part)
+        for marker in ("+", "-"):
+            marker_index = fractional_part.find(marker)
+            if marker_index != -1:
+                timezone_start = min(timezone_start, marker_index)
+
+        fraction = fractional_part[:timezone_start][:6].ljust(6, "0")
+        timezone_part = fractional_part[timezone_start:]
+        return datetime.fromisoformat(f"{timestamp_part}.{fraction}{timezone_part}")
 
     async def test_list_tools(self) -> None:
         """Test listing available tools."""
@@ -199,22 +256,9 @@ class KustoToolsLiveTester:
         kusto_tools = [tool for tool in tools if tool.startswith("kusto_")]
         print(f"Kusto tools found: {kusto_tools}")
 
-        expected_kusto_tools = [
-            "kusto_known_services",
-            "kusto_query",
-            "kusto_command",
-            "kusto_list_entities",
-            "kusto_describe_database",
-            "kusto_describe_database_entity",
-            "kusto_graph_query",
-            "kusto_sample_entity",
-            "kusto_ingest_inline_into_table",
-            "kusto_get_shots",
-        ]
-
-        missing_tools = set(expected_kusto_tools) - set(kusto_tools)
+        missing_tools = set(EXPECTED_KUSTO_TOOLS) - set(kusto_tools)
         if missing_tools:
-            print(f"⚠️  Missing expected tools: {missing_tools}")
+            raise AssertionError(f"Missing expected Kusto tools: {sorted(missing_tools)}")
         else:
             print("✅ All expected Kusto tools found")
 
@@ -255,8 +299,8 @@ class KustoToolsLiveTester:
         test_data = [
             ["databases", [self.test_cluster_uri, None], 8, None],
             ["tables", [self.test_cluster_uri, self.test_database], 50, None],
-            ["external-tables", [self.test_cluster_uri, self.test_database], 0, None],
-            ["materialized-views", [self.test_cluster_uri, self.test_database], 0, None],
+            ["external-table", [self.test_cluster_uri, self.test_database], 0, None],
+            ["materialized-view", [self.test_cluster_uri, self.test_database], 0, None],
             ["functions", [self.test_cluster_uri, self.test_database], 0, None],
             ["graphs", [self.test_cluster_uri, self.test_database], 0, None],
         ]
@@ -277,9 +321,9 @@ class KustoToolsLiveTester:
 
                     # Assert minimum count
                     assert len(parsed_data) >= min_expected_count, (
-                        f"Expected at least {min_expected_count} {entity_type}, "
+                        f"Expected at least {min_expected_count} {entity_type}, got {len(parsed_data)}. "
+                        f"Args: {json.dumps(call_args)}"
                     )
-                    "got {len(parsed_data)}. Args: {json.dumps(call_args)}"
                     print(f"    ✅ Found {len(parsed_data)} {entity_type}")
 
                     # Check expected first value if specified
@@ -334,7 +378,7 @@ class KustoToolsLiveTester:
                     scalar_value = parsed_data[0].get("print_0", "")
                     print(f"✅ Query succeeded, current time from Kusto: {scalar_value}")
                     if scalar_value:
-                        parsed_date = datetime.fromisoformat(scalar_value.replace("Z", "+00:00"))
+                        parsed_date = self._parse_kusto_datetime(scalar_value)
                         assert datetime.now(tz=timezone.utc) - parsed_date < timedelta(minutes=1), (
                             "Query result is stale"
                         )
@@ -387,6 +431,171 @@ class KustoToolsLiveTester:
         except Exception as e:
             print(f"❌ Error testing SQL query: {e}")
 
+    async def test_command(self) -> None:
+        """Test kusto_command with a read-only management command."""
+        print("\n🛠️  Testing kusto_command...")
+        if not self.client:
+            raise RuntimeError("Client not initialized")
+
+        result = await self.client.call_tool(
+            "kusto_command",
+            {
+                "command": ".show tables | project TableName | take 1",
+                "cluster_uri": self.test_cluster_uri,
+                "database": self.test_database,
+            },
+        )
+
+        if not result.get("success"):
+            raise AssertionError(f"kusto_command failed: {result}")
+
+        command_result = self._payload(result)
+        parsed_data = KustoFormatter.parse(command_result) or []
+        assert parsed_data, "Expected .show tables to return at least one table"
+        print(f"✅ kusto_command succeeded, first table: {parsed_data[0].get('TableName', parsed_data[0])}")
+
+    async def test_deeplink_from_query(self) -> None:
+        """Test kusto_deeplink_from_query for the public help cluster."""
+        print("\n🔗 Testing kusto_deeplink_from_query...")
+        if not self.client:
+            raise RuntimeError("Client not initialized")
+
+        query = "StormEvents | take 10"
+        result = await self.client.call_tool(
+            "kusto_deeplink_from_query",
+            {"cluster_uri": self.test_cluster_uri, "database": self.test_database, "query": query},
+        )
+
+        if not result.get("success"):
+            raise AssertionError(f"kusto_deeplink_from_query failed: {result}")
+
+        deeplink = self._payload(result)
+        if not isinstance(deeplink, str):
+            deeplink = result.get("content")
+        assert isinstance(deeplink, str), f"Expected deeplink string, got: {type(deeplink)}"
+
+        parsed = urlparse(deeplink)
+        assert parsed.scheme == "https", f"Expected HTTPS deeplink, got: {deeplink}"
+        assert parsed.netloc == "dataexplorer.azure.com", f"Expected ADX web explorer deeplink, got: {deeplink}"
+        assert "/clusters/help.kusto.windows.net/databases/Samples" in parsed.path, (
+            f"Expected help cluster and Samples database in deeplink, got: {deeplink}"
+        )
+        assert "query=" in parsed.query, f"Expected encoded query parameter in deeplink, got: {deeplink}"
+        print(f"✅ Deeplink generated: {deeplink[:120]}...")
+
+    async def test_show_queryplan(self) -> None:
+        """Test kusto_show_queryplan without executing the query."""
+        print("\n📈 Testing kusto_show_queryplan...")
+        if not self.client:
+            raise RuntimeError("Client not initialized")
+
+        query = (
+            "StormEvents "
+            "| where State == 'TEXAS' "
+            "| summarize EventCount=count() by EventType "
+            "| top 5 by EventCount desc"
+        )
+        result = await self.client.call_tool(
+            "kusto_show_queryplan",
+            {"query": query, "cluster_uri": self.test_cluster_uri, "database": self.test_database},
+        )
+
+        if not result.get("success"):
+            raise AssertionError(f"kusto_show_queryplan failed: {result}")
+
+        plan = self._payload(result)
+        assert isinstance(plan, dict), f"Expected query plan dictionary, got: {type(plan)}"
+        if plan.get("error"):
+            raise AssertionError(f"Query plan returned an error: {plan['error']}")
+
+        assert any(key in plan for key in ("stats", "relop_tree", "execution_hints")), (
+            f"Expected query plan details, got: {json.dumps(plan, indent=2)}"
+        )
+        if "stats" in plan:
+            print(f"✅ Query plan stats: {json.dumps(plan['stats'], indent=2)}")
+        else:
+            print("✅ Query plan returned successfully")
+
+    async def test_diagnostics(self) -> None:
+        """Test kusto_diagnostics against the help cluster."""
+        print("\n🩺 Testing kusto_diagnostics...")
+        if not self.client:
+            raise RuntimeError("Client not initialized")
+
+        result = await self.client.call_tool(
+            "kusto_diagnostics", {"cluster_uri": self.test_cluster_uri, "database": self.test_database}
+        )
+
+        if not result.get("success"):
+            raise AssertionError(f"kusto_diagnostics failed: {result}")
+
+        diagnostics = self._payload(result)
+        assert isinstance(diagnostics, dict), f"Expected diagnostics dictionary, got: {type(diagnostics)}"
+
+        expected_sections = {
+            "capacity",
+            "cluster",
+            "principal_roles",
+            "diagnostics",
+            "workload_groups",
+            "rowstores",
+            "ingestion_failures",
+        }
+        missing_sections = expected_sections - set(diagnostics)
+        assert not missing_sections, f"Missing diagnostics sections: {sorted(missing_sections)}"
+
+        successful_sections = [
+            name for name, value in diagnostics.items() if not (isinstance(value, dict) and "error" in value)
+        ]
+        assert successful_sections, f"Expected at least one diagnostics section to succeed: {diagnostics}"
+        print(f"✅ Diagnostics completed; successful sections: {successful_sections}")
+
+    async def test_get_shots(self) -> None:
+        """Test kusto_get_shots when configured, otherwise verify its validation path."""
+        print("\n🎯 Testing kusto_get_shots...")
+        if not self.client:
+            raise RuntimeError("Client not initialized")
+
+        shots_table = os.getenv("KUSTO_LIVE_SHOTS_TABLE") or os.getenv("KUSTO_SHOTS_TABLE")
+        embedding_endpoint = os.getenv("AZ_OPENAI_EMBEDDING_ENDPOINT")
+
+        if shots_table and embedding_endpoint:
+            result = await self.client.call_tool(
+                "kusto_get_shots",
+                {
+                    "prompt": "Find a few storm events in Texas",
+                    "cluster_uri": self.test_cluster_uri,
+                    "database": self.test_database,
+                    "shots_table_name": shots_table,
+                    "embedding_endpoint": embedding_endpoint,
+                    "sample_size": 1,
+                },
+            )
+
+            if not result.get("success"):
+                raise AssertionError(f"kusto_get_shots failed: {result}")
+
+            shots_result = self._payload(result)
+            parsed_data = KustoFormatter.parse(shots_result) or []
+            print(f"✅ kusto_get_shots returned {len(parsed_data)} shot(s)")
+            return
+
+        if shots_table and not embedding_endpoint:
+            print("⚠️  Skipping full kusto_get_shots call: AZ_OPENAI_EMBEDDING_ENDPOINT is not configured")
+            return
+
+        result = await self.client.call_tool(
+            "kusto_get_shots",
+            {
+                "prompt": "Find a few storm events in Texas",
+                "cluster_uri": self.test_cluster_uri,
+                "database": self.test_database,
+            },
+        )
+        assert not result.get("success"), "Expected kusto_get_shots to require a shots table when not configured"
+        assert "shots_table_name" in result.get("error", ""), f"Unexpected validation error: {result}"
+        print("✅ kusto_get_shots validation path confirmed")
+
     async def test_describe_database(self) -> None:
         """Test kusto_describe_database tool."""
         print("\n📋 Testing kusto_describe_database...")
@@ -436,7 +645,7 @@ class KustoToolsLiveTester:
 
         # Test data: [entity_name, entity_type, expected_schema_fields]
         test_data = [
-            ["StormEvents", "table", ["ColumnName", "ColumnType"]],
+            ["StormEvents", "table", ["Schema"]],
             # Add more entities as they are discovered
         ]
 
@@ -464,10 +673,8 @@ class KustoToolsLiveTester:
                     if parsed_data and expected_fields:
                         first_row = parsed_data[0]
                         for field in expected_fields:
-                            if field in first_row:
-                                print(f"      ✅ Found expected field: {field}")
-                            else:
-                                print(f"      ⚠️  Missing expected field: {field}")
+                            assert field in first_row, f"Missing expected field: {field}"
+                            print(f"      ✅ Found expected field: {field}")
                 else:
                     print(f"    ❌ Failed to describe {entity_type} '{entity_name}': {result}")
 
@@ -591,6 +798,11 @@ class KustoToolsLiveTester:
             await self.test_list_entities()
             await self.test_simple_query()
             await self.test_sql_query_with_crp()
+            await self.test_command()
+            await self.test_deeplink_from_query()
+            await self.test_show_queryplan()
+            await self.test_diagnostics()
+            await self.test_get_shots()
             await self.test_describe_database()
             await self.test_describe_database_entity()
             await self.test_sample_entity()

--- a/tests/live/test_kusto_tools_live.py
+++ b/tests/live/test_kusto_tools_live.py
@@ -175,8 +175,8 @@ class KustoToolsLiveTester:
 
     def __init__(self) -> None:
         self.client: McpClient | None = None
-        self.test_cluster_uri = "https://help.kusto.windows.net"
-        self.test_database = "Samples"
+        self.test_cluster_uri = os.getenv("KUSTO_LIVE_CLUSTER_URI", "https://help.kusto.windows.net")
+        self.test_database = os.getenv("KUSTO_LIVE_DATABASE", "Samples")
 
     async def setup(self) -> None:
         """Set up the MCP client connection."""

--- a/tests/live/test_kusto_tools_live_http.py
+++ b/tests/live/test_kusto_tools_live_http.py
@@ -480,6 +480,11 @@ def start_server(
         env["FABRIC_RTI_MCP_USER_MANAGED_IDENTITY_CLIENT_ID"] = additional_args.umi_client_id
 
     env["KUSTO_EAGER_CONNECT"] = "false"
+    env["KUSTO_ALLOW_UNKNOWN_SERVICES"] = "false"
+    env["FABRIC_RTI_AI_FOUNDRY_COMPATIBILITY_SCHEMA"] = "false"
+    env["FABRIC_RTI_KUSTO_DEEPLINK_STYLE"] = "adx"
+    env["FABRIC_RTI_KUSTO_RESPONSE_FORMAT"] = "kusto_response"
+    env.pop("PORT", None)
     if additional_args and hasattr(additional_args, "cluster_uri") and additional_args.cluster_uri:
         env["KUSTO_SERVICE_URI"] = additional_args.cluster_uri
     if additional_args and hasattr(additional_args, "database") and additional_args.database:


### PR DESCRIPTION
## Summary
- add read-only coverage for the remaining Kusto live-test tools
- pin live-test server environment for deterministic response format and transport
- add a manually triggered Live Tests GitHub Actions workflow using Azure OIDC

## Validation
- uv run ruff format fabric_rti_mcp
- uv run ty check fabric_rti_mcp
- uv run pytest
- uv run python -m tests.live.test_kusto_tools_live