### PR TITLE
Fix Kusto known service default database lookup

### DIFF
--- a/fabric_rti_mcp/services/kusto/kusto_config.py
+++ b/fabric_rti_mcp/services/kusto/kusto_config.py
@@ -16,6 +16,10 @@ class KustoServiceConfig:
     description: str | None = None
 
 
+def normalize_service_uri_key(service_uri: str) -> str:
+    return service_uri.strip().rstrip("/").lower()
+
+
 class KustoEnvVarNames:
     default_service_uri = "KUSTO_SERVICE_URI"
     default_service_default_db = "KUSTO_SERVICE_DEFAULT_DB"
@@ -156,8 +160,8 @@ class KustoConfig:
         config = KustoConfig.from_env()
         result: dict[str, KustoServiceConfig] = {}
         if config.default_service:
-            result[config.default_service.service_uri] = config.default_service
+            result[normalize_service_uri_key(config.default_service.service_uri)] = config.default_service
         if config.known_services is not None:
             for known_service in config.known_services:
-                result[known_service.service_uri] = known_service
+                result[normalize_service_uri_key(known_service.service_uri)] = known_service
         return result

--- a/fabric_rti_mcp/services/kusto/kusto_service.py
+++ b/fabric_rti_mcp/services/kusto/kusto_service.py
@@ -15,7 +15,7 @@ from azure.kusto.data import ClientRequestProperties, KustoConnectionStringBuild
 
 from fabric_rti_mcp import __version__  # type: ignore
 from fabric_rti_mcp.config import global_config, logger
-from fabric_rti_mcp.services.kusto.kusto_config import KustoConfig
+from fabric_rti_mcp.services.kusto.kusto_config import KustoConfig, normalize_service_uri_key
 from fabric_rti_mcp.services.kusto.kusto_connection import KustoConnection, sanitize_uri
 from fabric_rti_mcp.services.kusto.kusto_formatter import KustoFormatter, KustoResponseFormat
 
@@ -263,9 +263,10 @@ class KustoConnectionManager:
         # Connection not found, create a new one.
         known_services = KustoConfig.get_known_services()
         default_database = _DEFAULT_DB_NAME
+        service_key = normalize_service_uri_key(sanitized_uri)
 
-        if sanitized_uri in known_services:
-            default_database = known_services[sanitized_uri].default_database or _DEFAULT_DB_NAME
+        if service_key in known_services:
+            default_database = known_services[service_key].default_database or _DEFAULT_DB_NAME
         elif not CONFIG.allow_unknown_services:
             raise ValueError(
                 f"Service URI '{sanitized_uri}' is not in the list of approved services, "

--- a/tests/unit/kusto/test_kusto_service.py
+++ b/tests/unit/kusto/test_kusto_service.py
@@ -7,11 +7,40 @@ from azure.kusto.data.response import KustoResponseDataSet
 
 from fabric_rti_mcp import __version__
 from fabric_rti_mcp.services.kusto.kusto_service import (
+    KustoConnectionManager,
     kusto_command,
     kusto_diagnostics,
     kusto_query,
     kusto_show_queryplan,
 )
+
+
+@patch.dict(
+    "os.environ",
+    {
+        "KUSTO_SERVICE_URI": "https://demo11.westus.kusto.windows.net/",
+        "KUSTO_SERVICE_DEFAULT_DB": "ML",
+        "KUSTO_KNOWN_SERVICES": json.dumps(
+            [
+                {"service_uri": "https://demo11.westus.kusto.windows.net/", "default_database": "ML"},
+                {"service_uri": "https://demo12.westus.kusto.windows.net/", "default_database": "Datasets"},
+                {"service_uri": "https://kuskus.kusto.windows.net/", "default_database": "Kuskus"},
+            ]
+        ),
+        "KUSTO_ALLOW_UNKNOWN_SERVICES": "true",
+    },
+    clear=False,
+)
+@patch("fabric_rti_mcp.services.kusto.kusto_service.KustoConnection")
+def test_connection_manager_uses_known_service_default_database(mock_kusto_connection: MagicMock) -> None:
+    manager = KustoConnectionManager()
+
+    manager.get("HTTPS://DEMO12.WESTUS.KUSTO.WINDOWS.NET/")
+
+    mock_kusto_connection.assert_called_once_with(
+        "HTTPS://DEMO12.WESTUS.KUSTO.WINDOWS.NET",
+        default_database="Datasets",
+    )
 
 
 @patch("fabric_rti_mcp.services.kusto.kusto_service.CONFIG")


### PR DESCRIPTION
## Summary
- Normalize configured Kusto service URIs before matching known services
- Use the matching service entry's default_database before falling back to the global default
- Add a regression test for trailing-slash/case differences with a per-service default database

## Validation
- uv run ruff format fabric_rti_mcp tests/unit/kusto/test_kusto_service.py
- uv run ty check fabric_rti_mcp
- uv run pytest
- uv run ruff check fabric_rti_mcp tests/unit/kusto/test_kusto_service.py