### PR TITLE
Fix Kusto known service default database lookup

### DIFF
--- a/fabric_rti_mcp/services/kusto/kusto_config.py
+++ b/fabric_rti_mcp/services/kusto/kusto_config.py
@@ -16,6 +16,16 @@ class KustoServiceConfig:
     description: str | None = None
 
 
+def normalize_service_uri_key(service_uri: str) -> str:
+    """Canonical key for matching/caching Kusto service URIs.
+
+    Hostnames and trailing slashes are not semantically significant for cluster
+    identity, so we strip whitespace, drop a trailing slash, and lowercase to
+    avoid duplicate cache entries and missed known-service lookups.
+    """
+    return service_uri.strip().rstrip("/").lower()
+
+
 class KustoEnvVarNames:
     default_service_uri = "KUSTO_SERVICE_URI"
     default_service_default_db = "KUSTO_SERVICE_DEFAULT_DB"
@@ -155,9 +165,20 @@ class KustoConfig:
     def get_known_services() -> dict[str, KustoServiceConfig]:
         config = KustoConfig.from_env()
         result: dict[str, KustoServiceConfig] = {}
+
+        def _add(service: KustoServiceConfig) -> None:
+            key = normalize_service_uri_key(service.service_uri)
+            existing = result.get(key)
+            if existing is not None:
+                logger.warning(
+                    f"Duplicate Kusto known service entry for normalized key '{key}': "
+                    f"'{existing.service_uri}' is overridden by '{service.service_uri}'."
+                )
+            result[key] = service
+
         if config.default_service:
-            result[config.default_service.service_uri] = config.default_service
+            _add(config.default_service)
         if config.known_services is not None:
             for known_service in config.known_services:
-                result[known_service.service_uri] = known_service
+                _add(known_service)
         return result

--- a/fabric_rti_mcp/services/kusto/kusto_service.py
+++ b/fabric_rti_mcp/services/kusto/kusto_service.py
@@ -15,7 +15,7 @@ from azure.kusto.data import ClientRequestProperties, KustoConnectionStringBuild
 
 from fabric_rti_mcp import __version__  # type: ignore
 from fabric_rti_mcp.config import global_config, logger
-from fabric_rti_mcp.services.kusto.kusto_config import KustoConfig
+from fabric_rti_mcp.services.kusto.kusto_config import KustoConfig, normalize_service_uri_key
 from fabric_rti_mcp.services.kusto.kusto_connection import KustoConnection, sanitize_uri
 from fabric_rti_mcp.services.kusto.kusto_formatter import KustoFormatter, KustoResponseFormat
 
@@ -256,16 +256,17 @@ class KustoConnectionManager:
         This method is the single entry point for accessing connections.
         """
         sanitized_uri = sanitize_uri(cluster_uri)
+        cache_key = normalize_service_uri_key(sanitized_uri)
 
-        if sanitized_uri in self._cache:
-            return self._cache[sanitized_uri]
+        if cache_key in self._cache:
+            return self._cache[cache_key]
 
         # Connection not found, create a new one.
         known_services = KustoConfig.get_known_services()
         default_database = _DEFAULT_DB_NAME
 
-        if sanitized_uri in known_services:
-            default_database = known_services[sanitized_uri].default_database or _DEFAULT_DB_NAME
+        if cache_key in known_services:
+            default_database = known_services[cache_key].default_database or _DEFAULT_DB_NAME
         elif not CONFIG.allow_unknown_services:
             raise ValueError(
                 f"Service URI '{sanitized_uri}' is not in the list of approved services, "
@@ -273,7 +274,7 @@ class KustoConnectionManager:
             )
 
         connection = KustoConnection(sanitized_uri, default_database=default_database)
-        self._cache[sanitized_uri] = connection
+        self._cache[cache_key] = connection
         return connection
 
 

--- a/tests/unit/kusto/test_kusto_service.py
+++ b/tests/unit/kusto/test_kusto_service.py
@@ -6,12 +6,85 @@ from azure.kusto.data import ClientRequestProperties
 from azure.kusto.data.response import KustoResponseDataSet
 
 from fabric_rti_mcp import __version__
+from fabric_rti_mcp.services.kusto.kusto_config import KustoConfig
 from fabric_rti_mcp.services.kusto.kusto_service import (
+    KustoConnectionManager,
     kusto_command,
     kusto_diagnostics,
     kusto_query,
     kusto_show_queryplan,
 )
+
+_KNOWN_SERVICES_ENV = {
+    "KUSTO_SERVICE_URI": "https://demo11.westus.kusto.windows.net/",
+    "KUSTO_SERVICE_DEFAULT_DB": "ML",
+    "KUSTO_KNOWN_SERVICES": json.dumps(
+        [
+            {"service_uri": "https://demo11.westus.kusto.windows.net/", "default_database": "ML"},
+            {"service_uri": "https://demo12.westus.kusto.windows.net/", "default_database": "Datasets"},
+            {"service_uri": "https://kuskus.kusto.windows.net/", "default_database": "Kuskus"},
+        ]
+    ),
+    "KUSTO_ALLOW_UNKNOWN_SERVICES": "true",
+}
+
+
+@patch.dict("os.environ", _KNOWN_SERVICES_ENV, clear=True)
+@patch("fabric_rti_mcp.services.kusto.kusto_service.KustoConnection")
+def test_connection_manager_uses_known_service_default_database(mock_kusto_connection: MagicMock) -> None:
+    """Known-service lookup matches even when the caller's URI differs in case/trailing slash."""
+    manager = KustoConnectionManager()
+
+    manager.get("HTTPS://DEMO12.WESTUS.KUSTO.WINDOWS.NET/")
+
+    mock_kusto_connection.assert_called_once_with(
+        "HTTPS://DEMO12.WESTUS.KUSTO.WINDOWS.NET",
+        default_database="Datasets",
+    )
+
+
+@patch.dict("os.environ", _KNOWN_SERVICES_ENV, clear=True)
+@patch("fabric_rti_mcp.services.kusto.kusto_service.KustoConnection")
+def test_connection_manager_caches_by_normalized_uri(mock_kusto_connection: MagicMock) -> None:
+    """Calls that differ only in case/trailing slash share the same cached connection."""
+    mock_kusto_connection.return_value = MagicMock()
+    manager = KustoConnectionManager()
+
+    first = manager.get("https://demo12.westus.kusto.windows.net")
+    second = manager.get("HTTPS://DEMO12.WESTUS.KUSTO.WINDOWS.NET/")
+    third = manager.get("https://demo12.westus.kusto.windows.net/")
+
+    assert first is second is third
+    mock_kusto_connection.assert_called_once()
+
+
+@patch.dict(
+    "os.environ",
+    {
+        "KUSTO_KNOWN_SERVICES": json.dumps(
+            [
+                {"service_uri": "https://demo.kusto.windows.net/", "default_database": "First"},
+                {"service_uri": "HTTPS://DEMO.KUSTO.WINDOWS.NET", "default_database": "Second"},
+            ]
+        ),
+        "KUSTO_ALLOW_UNKNOWN_SERVICES": "true",
+    },
+    clear=True,
+)
+def test_get_known_services_warns_on_duplicate_normalized_keys(caplog: pytest.LogCaptureFixture) -> None:
+    """Duplicate normalized keys log a warning naming both URIs and the winner."""
+    with caplog.at_level("WARNING", logger="fabric_rti_mcp"):
+        services = KustoConfig.get_known_services()
+
+    assert len(services) == 1
+    winner = next(iter(services.values()))
+    assert winner.default_database == "Second"
+    assert any(
+        "Duplicate Kusto known service" in record.message
+        and "https://demo.kusto.windows.net/" in record.message
+        and "HTTPS://DEMO.KUSTO.WINDOWS.NET" in record.message
+        for record in caplog.records
+    )
 
 
 @patch("fabric_rti_mcp.services.kusto.kusto_service.CONFIG")

--- a/tests/unit/kusto/test_kusto_service.py
+++ b/tests/unit/kusto/test_kusto_service.py
@@ -79,12 +79,11 @@ def test_get_known_services_warns_on_duplicate_normalized_keys(caplog: pytest.Lo
     assert len(services) == 1
     winner = next(iter(services.values()))
     assert winner.default_database == "Second"
-    assert any(
-        "Duplicate Kusto known service" in record.message
-        and "https://demo.kusto.windows.net/" in record.message
-        and "HTTPS://DEMO.KUSTO.WINDOWS.NET" in record.message
-        for record in caplog.records
+    expected_message = (
+        "Duplicate Kusto known service entry for normalized key 'https://demo.kusto.windows.net': "
+        "'https://demo.kusto.windows.net/' is overridden by 'HTTPS://DEMO.KUSTO.WINDOWS.NET'."
     )
+    assert any(record.message == expected_message for record in caplog.records)
 
 
 @patch("fabric_rti_mcp.services.kusto.kusto_service.CONFIG")


### PR DESCRIPTION
Normalize Kusto service URIs (case- and trailing-slash-insensitive) when matching known services and when caching connections, so per-service default databases are picked up consistently regardless of how callers spell the URI.

- Add normalize_service_uri_key() and use it in KustoConfig.get_known_services() so dict keys are canonical.

- Use the normalized key for both the known-services lookup and the KustoConnectionManager._cache key, preventing duplicate cached KustoConnection instances for the same cluster spelled differently.

- Detect duplicate normalized entries in get_known_services() and log a warning naming both original URIs and the winning entry, instead of silently overwriting.

- Add regression tests covering: case/trailing-slash matching for the known-service default database, cache deduplication across spellings, and the duplicate-key warning. Tests use clear=True for hermetic env patching.