### PR TITLE
fix(kusto): convert servertimeout to timedelta in client_request_properties

### DIFF
--- a/fabric_rti_mcp/services/kusto/kusto_service.py
+++ b/fabric_rti_mcp/services/kusto/kusto_service.py
@@ -5,9 +5,11 @@ import functools
 import gzip
 import inspect
 import json
+import re
 import uuid
 from collections.abc import Callable
 from dataclasses import asdict
+from datetime import timedelta
 from typing import Any, TypeVar
 from urllib.parse import quote, urlparse
 
@@ -316,6 +318,25 @@ _BLOCKED_CRP_KEYS = frozenset(
     }
 )
 
+_TIMESPAN_RE = re.compile(r"^(\d+):(\d{1,2}):(\d{1,2})$")
+
+
+def _parse_servertimeout(value: str) -> timedelta:
+    """Parse an ``HH:MM:SS`` string into a ``timedelta``.
+
+    The Azure Kusto SDK requires ``servertimeout`` to be a ``timedelta`` because
+    it performs ``timeout + client_server_delta`` arithmetic internally. We
+    intentionally accept only the ``HH:MM:SS`` form so agents have a single,
+    unambiguous format to produce.
+    """
+    if not isinstance(value, str):
+        raise ValueError(f"servertimeout must be a string in 'HH:MM:SS' format, got {type(value).__name__}: {value!r}")
+    match = _TIMESPAN_RE.match(value.strip())
+    if not match:
+        raise ValueError(f"servertimeout must be in 'HH:MM:SS' format, got {value!r}")
+    hours, minutes, seconds = (int(g) for g in match.groups())
+    return timedelta(hours=hours, minutes=minutes, seconds=seconds)
+
 
 def _crp(
     action: str, is_destructive: bool, ignore_readonly: bool, client_request_properties: dict[str, Any] | None = None
@@ -326,13 +347,13 @@ def _crp(
     if not is_destructive and not ignore_readonly:
         crp.set_option("request_readonly", True)
 
-    # Set global timeout if configured
+    # The Azure Kusto SDK expects servertimeout as a timedelta — it adds
+    # client_server_delta (also a timedelta) to it in client_base.py.
     if CONFIG.timeout_seconds is not None:
-        # Convert seconds to timespan format (HH:MM:SS)
-        hours, remainder = divmod(CONFIG.timeout_seconds, 3600)
-        minutes, seconds = divmod(remainder, 60)
-        timeout_str = f"{hours:02d}:{minutes:02d}:{seconds:02d}"
-        crp.set_option("servertimeout", timeout_str)
+        crp.set_option(
+            ClientRequestProperties.request_timeout_option_name,
+            timedelta(seconds=CONFIG.timeout_seconds),
+        )
 
     if client_request_properties:
         blocked = [k for k in client_request_properties if k.lower() in _BLOCKED_CRP_KEYS]
@@ -341,6 +362,8 @@ def _crp(
                 f"Client request properties {blocked} are security-sensitive and cannot be overridden via MCP tools"
             )
         for key, value in client_request_properties.items():
+            if key == ClientRequestProperties.request_timeout_option_name:
+                value = _parse_servertimeout(value)
             crp.set_option(key, value)
 
     return crp

--- a/tests/unit/kusto/test_global_timeout.py
+++ b/tests/unit/kusto/test_global_timeout.py
@@ -1,6 +1,7 @@
 """Test global timeout configuration for Kusto tools."""
 
 import os
+from datetime import timedelta
 from unittest.mock import Mock, patch
 
 from azure.kusto.data import ClientRequestProperties
@@ -54,10 +55,9 @@ def test_global_timeout_applied_to_query(mock_get_connection: Mock) -> None:
     crp = call_args[0][2]  # Third argument should be ClientRequestProperties
 
     assert isinstance(crp, ClientRequestProperties)
-    # The timeout should be set as server timeout option in HH:MM:SS format
-    # 600 seconds = 10 minutes = 00:10:00
-    expected_timeout = "00:10:00"
-    assert crp._options.get("servertimeout") == expected_timeout
+    # The SDK expects servertimeout as a timedelta — it adds client_server_delta to it internally.
+    # 600 seconds = 10 minutes
+    assert crp._options.get("servertimeout") == timedelta(seconds=600)
 
 
 @patch("fabric_rti_mcp.services.kusto.kusto_service.get_kusto_connection")

--- a/tests/unit/kusto/test_servertimeout_conversion.py
+++ b/tests/unit/kusto/test_servertimeout_conversion.py
@@ -1,0 +1,85 @@
+"""Tests for ``servertimeout`` conversion in user-supplied client_request_properties."""
+
+from datetime import timedelta
+from unittest.mock import Mock, patch
+
+import pytest
+from azure.kusto.data import ClientRequestProperties
+
+from fabric_rti_mcp.services.kusto.kusto_service import _parse_servertimeout, kusto_query
+
+
+def test_parse_servertimeout_hh_mm_ss() -> None:
+    """An 'HH:MM:SS' string is converted to the corresponding timedelta."""
+    assert _parse_servertimeout("00:03:00") == timedelta(minutes=3)
+
+
+def test_parse_servertimeout_combines_hours_minutes_seconds() -> None:
+    """All three components contribute to the resulting timedelta in the right order."""
+    assert _parse_servertimeout("01:30:45") == timedelta(hours=1, minutes=30, seconds=45)
+
+
+def test_parse_servertimeout_strips_whitespace() -> None:
+    """Leading/trailing whitespace around the timespan is tolerated."""
+    assert _parse_servertimeout("  00:03:00  ") == timedelta(minutes=3)
+
+
+def test_parse_servertimeout_rejects_non_string() -> None:
+    """Non-string values are rejected — agents must produce 'HH:MM:SS' strings."""
+    with pytest.raises(ValueError, match="must be a string"):
+        _parse_servertimeout(180)  # type: ignore[arg-type]
+
+
+def test_parse_servertimeout_rejects_invalid_format() -> None:
+    """Strings that are not in 'HH:MM:SS' form are rejected."""
+    with pytest.raises(ValueError, match="HH:MM:SS"):
+        _parse_servertimeout("3m")
+
+
+@patch("fabric_rti_mcp.services.kusto.kusto_service.get_kusto_connection")
+def test_servertimeout_string_converted_end_to_end(mock_get_connection: Mock) -> None:
+    """servertimeout in client_request_properties is converted to a timedelta on the CRP."""
+    mock_connection = Mock()
+    mock_connection.default_database = "TestDB"
+    mock_client = Mock()
+    mock_result = Mock()
+    mock_result.primary_results = None
+    mock_client.execute.return_value = mock_result
+    mock_connection.query_client = mock_client
+    mock_get_connection.return_value = mock_connection
+
+    with patch("fabric_rti_mcp.services.kusto.kusto_service.CONFIG") as mock_config:
+        mock_config.timeout_seconds = None
+        kusto_query(
+            "TestQuery",
+            "https://test.kusto.windows.net",
+            client_request_properties={"servertimeout": "00:03:00"},
+        )
+
+    crp = mock_client.execute.call_args[0][2]
+    assert isinstance(crp, ClientRequestProperties)
+    assert crp._options["servertimeout"] == timedelta(minutes=3)
+
+
+@patch("fabric_rti_mcp.services.kusto.kusto_service.get_kusto_connection")
+def test_user_servertimeout_overrides_global_timeout(mock_get_connection: Mock) -> None:
+    """User-supplied servertimeout wins over CONFIG.timeout_seconds."""
+    mock_connection = Mock()
+    mock_connection.default_database = "TestDB"
+    mock_client = Mock()
+    mock_result = Mock()
+    mock_result.primary_results = None
+    mock_client.execute.return_value = mock_result
+    mock_connection.query_client = mock_client
+    mock_get_connection.return_value = mock_connection
+
+    with patch("fabric_rti_mcp.services.kusto.kusto_service.CONFIG") as mock_config:
+        mock_config.timeout_seconds = 600  # 10 minutes
+        kusto_query(
+            "TestQuery",
+            "https://test.kusto.windows.net",
+            client_request_properties={"servertimeout": "00:01:00"},
+        )
+
+    crp = mock_client.execute.call_args[0][2]
+    assert crp._options["servertimeout"] == timedelta(minutes=1)


### PR DESCRIPTION
Fixes #137. Supersedes #136.

## Problem

Passing `servertimeout` via `client_request_properties` on any Kusto tool crashes with:

```
TypeError: can only concatenate str (not "datetime.timedelta") to str
```

The Azure Kusto SDK does `timeout + client_server_delta` (a `timedelta`) on `servertimeout`, but `_crp()` passes user-supplied values through as-is (typically strings).

The same latent bug existed in the global-timeout branch, which formatted `CONFIG.timeout_seconds` as `HH:MM:SS` before `set_option`.

### Reproduction

```python
kusto_query(
    query="MyTable | take 1",
    cluster_uri="https://mycluster.kusto.windows.net",
    client_request_properties={"servertimeout": "00:03:00"},
)
```

## Fix

- New `_parse_servertimeout(value: str) -> timedelta` helper. **Strict**: only accepts the canonical `HH:MM:SS` string. Non-strings and non-matching strings raise `ValueError` with a clear message. One canonical format = one error mode = simpler agent contract.
- `_crp()` runs the helper when `key == ClientRequestProperties.request_timeout_option_name` (matches the SDK constant rather than hard-coding the string).
- Global-timeout branch now uses `timedelta(seconds=CONFIG.timeout_seconds)` directly — no more `divmod` / format-string round-trip.
- Module-level pre-compiled regex.

## Tests

- `test_global_timeout_applied_to_query` updated to expect `timedelta(seconds=600)`.
- New `tests/unit/kusto/test_servertimeout_conversion.py` (7 tests):
  - happy path (`00:03:00`)
  - all three components combined (`01:30:45`)
  - whitespace tolerated
  - non-string rejected
  - invalid format rejected
  - end-to-end through `kusto_query` → `crp._options["servertimeout"]` is a `timedelta`
  - user CRP overrides `CONFIG.timeout_seconds`

All 116 kusto unit tests pass; ruff format/check clean.

## Relationship to #136

This branches off current `main` and addresses the four review comments left on #136:

1. _"maybe compile once and reuse?"_ — regex is module-level.
2. _"don't assume, match"_ — uses `ClientRequestProperties.request_timeout_option_name`.
3. _"Let's just pick one and go with it. I'm very much for HH:MM:SS"_ — only `HH:MM:SS` is accepted; `int`/`float`/`timedelta` branches dropped.
4. _"the type declaration needs to be simple. we should only expect strings here"_ — helper signature is `(value: str) -> timedelta`; non-string values raise.
