### PR TITLE
Fix Fabric API caller authentication

### DIFF
--- a/fabric_rti_mcp/authentication/auth_context.py
+++ b/fabric_rti_mcp/authentication/auth_context.py
@@ -35,11 +35,9 @@ class BearerTokenCredential(TokenCredential):
 
 
 def get_azure_credential_or_http_header_token(
-    azure_credential: TokenCredential | Callable[[], TokenCredential],
+    azure_credential_factory: Callable[[], TokenCredential],
 ) -> TokenCredential:
-    """Use the HTTP request bearer token when present, otherwise use the supplied Azure credential."""
+    """Use the HTTP request bearer token when present, otherwise create an Azure credential."""
     if get_auth_token():
         return BearerTokenCredential()
-    if callable(azure_credential):
-        return azure_credential()
-    return azure_credential
+    return azure_credential_factory()

--- a/fabric_rti_mcp/authentication/auth_context.py
+++ b/fabric_rti_mcp/authentication/auth_context.py
@@ -1,0 +1,18 @@
+from contextvars import ContextVar, Token
+
+_request_token: ContextVar[str | None] = ContextVar("_request_token", default=None)
+
+
+def set_auth_token(token: str | None) -> Token[str | None]:
+    """Set the auth token for the current request context."""
+    return _request_token.set(token)
+
+
+def get_auth_token() -> str | None:
+    """Get the auth token from the current request context."""
+    return _request_token.get()
+
+
+def reset_auth_token(context_token: Token[str | None]) -> None:
+    """Reset the auth token context to its previous value."""
+    _request_token.reset(context_token)

--- a/fabric_rti_mcp/authentication/auth_context.py
+++ b/fabric_rti_mcp/authentication/auth_context.py
@@ -1,9 +1,15 @@
-from contextvars import ContextVar, Token
+import time
+from collections.abc import Callable
+from contextvars import ContextVar
+from contextvars import Token as ContextToken
+from typing import Any
+
+from azure.core.credentials import AccessToken, TokenCredential
 
 _request_token: ContextVar[str | None] = ContextVar("_request_token", default=None)
 
 
-def set_auth_token(token: str | None) -> Token[str | None]:
+def set_auth_token(token: str | None) -> ContextToken[str | None]:
     """Set the auth token for the current request context."""
     return _request_token.set(token)
 
@@ -13,6 +19,27 @@ def get_auth_token() -> str | None:
     return _request_token.get()
 
 
-def reset_auth_token(context_token: Token[str | None]) -> None:
+def reset_auth_token(context_token: ContextToken[str | None]) -> None:
     """Reset the auth token context to its previous value."""
     _request_token.reset(context_token)
+
+
+class BearerTokenCredential(TokenCredential):
+    """A credential that reads the bearer token from the current request's ContextVar on each call."""
+
+    def get_token(self, *scopes: str, **kwargs: Any) -> AccessToken:
+        token = get_auth_token()
+        if not token:
+            raise ValueError("No auth token available in request context")
+        return AccessToken(token=token, expires_on=int(time.time()) + 3600)
+
+
+def get_azure_credential_or_http_header_token(
+    azure_credential: TokenCredential | Callable[[], TokenCredential],
+) -> TokenCredential:
+    """Use the HTTP request bearer token when present, otherwise use the supplied Azure credential."""
+    if get_auth_token():
+        return BearerTokenCredential()
+    if callable(azure_credential):
+        return azure_credential()
+    return azure_credential

--- a/fabric_rti_mcp/authentication/auth_context.py
+++ b/fabric_rti_mcp/authentication/auth_context.py
@@ -1,10 +1,10 @@
 import time
-from collections.abc import Callable
 from contextvars import ContextVar
 from contextvars import Token as ContextToken
 from typing import Any
 
 from azure.core.credentials import AccessToken, TokenCredential
+from azure.identity import DefaultAzureCredential
 
 _request_token: ContextVar[str | None] = ContextVar("_request_token", default=None)
 
@@ -34,10 +34,16 @@ class BearerTokenCredential(TokenCredential):
         return AccessToken(token=token, expires_on=int(time.time()) + 3600)
 
 
-def get_azure_credential_or_http_header_token(
-    azure_credential_factory: Callable[[], TokenCredential],
-) -> TokenCredential:
-    """Use the HTTP request bearer token when present, otherwise create an Azure credential."""
+def get_azure_credential_or_http_header_token(authority: str | None = None) -> TokenCredential:
+    """Use the HTTP request bearer token when present, otherwise create a DefaultAzureCredential."""
     if get_auth_token():
         return BearerTokenCredential()
-    return azure_credential_factory()
+
+    credential_args: dict[str, Any] = {
+        "exclude_shared_token_cache_credential": True,
+        "exclude_interactive_browser_credential": False,
+    }
+    if authority:
+        credential_args["authority"] = authority
+
+    return DefaultAzureCredential(**credential_args)

--- a/fabric_rti_mcp/authentication/auth_middleware.py
+++ b/fabric_rti_mcp/authentication/auth_middleware.py
@@ -13,11 +13,11 @@ from starlette.requests import Request
 from starlette.responses import JSONResponse
 from starlette.types import ASGIApp
 
+from fabric_rti_mcp.authentication.auth_context import reset_auth_token, set_auth_token
 from fabric_rti_mcp.authentication.token_obo_exchanger import TokenOboExchanger
 from fabric_rti_mcp.config import global_config as config
 from fabric_rti_mcp.config import logger
 from fabric_rti_mcp.config.obo import obo_config
-from fabric_rti_mcp.services.kusto.kusto_connection import set_auth_token
 
 # Secure asymmetric algorithms allowed for JWT validation.
 # Microsoft Entra ID uses RS256 (per https://login.microsoftonline.com/common/v2.0/.well-known/openid-configuration).
@@ -232,24 +232,26 @@ class AuthMiddleware(BaseHTTPMiddleware):
                 )
 
             # Store the token for use by services
-            set_auth_token(token)
+            auth_context_token = set_auth_token(token)
+            try:
+                token_payload = decode_jwt_token(token)
 
-            token_payload = decode_jwt_token(token)
+                audience = token_payload.get("aud", "N/A")
+                tenant_id = token_payload.get("tid", "N/A")
+                scopes = token_payload.get("scp", token_payload.get("roles", "N/A"))
 
-            audience = token_payload.get("aud", "N/A")
-            tenant_id = token_payload.get("tid", "N/A")
-            scopes = token_payload.get("scp", token_payload.get("roles", "N/A"))
+                logger.info(f"Token audience: {audience}")
+                logger.info(f"Token tenant ID: {tenant_id}")
+                logger.info(f"Token scopes/roles: {scopes}")
 
-            logger.info(f"Token audience: {audience}")
-            logger.info(f"Token tenant ID: {tenant_id}")
-            logger.info(f"Token scopes/roles: {scopes}")
+                # Continue with request
+                response = await call_next(request)
 
-            # Continue with request
-            response = await call_next(request)
+                logger.info(f"Response status code: {response.status_code}")
 
-            logger.info(f"Response status code: {response.status_code}")
-
-            return response
+                return response
+            finally:
+                reset_auth_token(auth_context_token)
 
         except Exception as e:
             logger.error(f"Error in auth middleware: {e}")

--- a/fabric_rti_mcp/fabric_api_http_client.py
+++ b/fabric_rti_mcp/fabric_api_http_client.py
@@ -52,7 +52,7 @@ class FabricAPIHttpClient:
     def _get_access_token(self) -> str:
         try:
             # Get token from Azure credential
-            credential = get_azure_credential_or_http_header_token(self.credential)
+            credential = get_azure_credential_or_http_header_token(lambda: self.credential)
             token = credential.get_token(self.token_scope)
 
             if not token:

--- a/fabric_rti_mcp/fabric_api_http_client.py
+++ b/fabric_rti_mcp/fabric_api_http_client.py
@@ -4,8 +4,6 @@ from contextvars import copy_context
 from typing import Any, cast
 
 import httpx
-from azure.core.credentials import TokenCredential
-from azure.identity import DefaultAzureCredential
 
 from fabric_rti_mcp.authentication.auth_context import get_azure_credential_or_http_header_token
 from fabric_rti_mcp.config import GlobalFabricRTIConfig, logger
@@ -31,28 +29,14 @@ class FabricAPIHttpClient:
             api_base_url = config.fabric_api_base
 
         self.api_base_url = api_base_url.rstrip("/")
-        self.credential = self._get_credential()
         self.token_scope = "https://api.fabric.microsoft.com/.default"
         self._cached_token = None
         self._token_expiry = None
 
-    def _get_credential(self) -> TokenCredential:
-        """
-        Get Azure credential for authentication.
-        This ensures consistent authentication behavior across all Fabric services.
-
-        Uses the user's default tenant, allowing the client to work
-        for users in any tenant (not hard-coded to Microsoft's tenant).
-        """
-        return DefaultAzureCredential(
-            exclude_shared_token_cache_credential=True,
-            exclude_interactive_browser_credential=False,
-        )
-
     def _get_access_token(self) -> str:
         try:
             # Get token from Azure credential
-            credential = get_azure_credential_or_http_header_token(lambda: self.credential)
+            credential = get_azure_credential_or_http_header_token()
             token = credential.get_token(self.token_scope)
 
             if not token:

--- a/fabric_rti_mcp/fabric_api_http_client.py
+++ b/fabric_rti_mcp/fabric_api_http_client.py
@@ -1,10 +1,12 @@
 import asyncio
 from collections.abc import Coroutine
+from contextvars import copy_context
 from typing import Any, cast
 
 import httpx
 from azure.identity import ChainedTokenCredential, DefaultAzureCredential
 
+from fabric_rti_mcp.authentication.auth_context import get_auth_token
 from fabric_rti_mcp.config import GlobalFabricRTIConfig, logger
 
 
@@ -47,6 +49,11 @@ class FabricAPIHttpClient:
         )
 
     def _get_access_token(self) -> str:
+        request_token = get_auth_token()
+        if request_token:
+            logger.debug("Using request auth token for Fabric API call")
+            return request_token
+
         try:
             # Get token from Azure credential
             token = self.credential.get_token(self.token_scope)
@@ -64,7 +71,6 @@ class FabricAPIHttpClient:
     def _get_headers(self, extra_headers: dict[str, str] | None = None) -> dict[str, str]:
         access_token = self._get_access_token()
         headers = {
-            "Authorization": f"Bearer {access_token}",
             "Content-Type": "application/json",
             "Accept": "application/json",
         }
@@ -73,6 +79,7 @@ class FabricAPIHttpClient:
         if extra_headers:
             headers.update(extra_headers)
 
+        headers["Authorization"] = f"Bearer {access_token}"
         return headers
 
     def _run_async_operation(self, coro: Coroutine[Any, Any, Any]) -> Any:
@@ -82,12 +89,14 @@ class FabricAPIHttpClient:
             # If we're already in an event loop, we need to run in a thread
             import concurrent.futures
 
+            context = copy_context()
+
             def run_in_thread() -> Any:
                 # Create a new event loop for this thread
                 new_loop = asyncio.new_event_loop()
                 asyncio.set_event_loop(new_loop)
                 try:
-                    return new_loop.run_until_complete(coro)
+                    return context.run(new_loop.run_until_complete, coro)
                 finally:
                     new_loop.close()
 

--- a/fabric_rti_mcp/fabric_api_http_client.py
+++ b/fabric_rti_mcp/fabric_api_http_client.py
@@ -4,9 +4,10 @@ from contextvars import copy_context
 from typing import Any, cast
 
 import httpx
-from azure.identity import ChainedTokenCredential, DefaultAzureCredential
+from azure.core.credentials import TokenCredential
+from azure.identity import DefaultAzureCredential
 
-from fabric_rti_mcp.authentication.auth_context import get_auth_token
+from fabric_rti_mcp.authentication.auth_context import get_azure_credential_or_http_header_token
 from fabric_rti_mcp.config import GlobalFabricRTIConfig, logger
 
 
@@ -35,7 +36,7 @@ class FabricAPIHttpClient:
         self._cached_token = None
         self._token_expiry = None
 
-    def _get_credential(self) -> ChainedTokenCredential:
+    def _get_credential(self) -> TokenCredential:
         """
         Get Azure credential for authentication.
         This ensures consistent authentication behavior across all Fabric services.
@@ -49,14 +50,10 @@ class FabricAPIHttpClient:
         )
 
     def _get_access_token(self) -> str:
-        request_token = get_auth_token()
-        if request_token:
-            logger.debug("Using request auth token for Fabric API call")
-            return request_token
-
         try:
             # Get token from Azure credential
-            token = self.credential.get_token(self.token_scope)
+            credential = get_azure_credential_or_http_header_token(self.credential)
+            token = credential.get_token(self.token_scope)
 
             if not token:
                 raise Exception("Failed to acquire token from Azure credential")

--- a/fabric_rti_mcp/services/kusto/kusto_connection.py
+++ b/fabric_rti_mcp/services/kusto/kusto_connection.py
@@ -1,5 +1,4 @@
 import time
-from contextvars import ContextVar
 from typing import Any
 
 from azure.core.credentials import AccessToken, TokenCredential
@@ -7,18 +6,8 @@ from azure.identity import DefaultAzureCredential
 from azure.kusto.data import KustoClient, KustoConnectionStringBuilder
 from azure.kusto.ingest import KustoStreamingIngestClient
 
-# Thread-safe context variable to store the current request's auth token
-_request_token: ContextVar[str | None] = ContextVar("_request_token", default=None)
-
-
-def set_auth_token(token: str | None) -> None:
-    """Set the auth token for the current request context"""
-    _request_token.set(token)
-
-
-def get_auth_token() -> str | None:
-    """Get the auth token from the current request context"""
-    return _request_token.get()
+from fabric_rti_mcp.authentication.auth_context import get_auth_token
+from fabric_rti_mcp.authentication.auth_context import set_auth_token as set_auth_token
 
 
 class BearerTokenCredential(TokenCredential):

--- a/fabric_rti_mcp/services/kusto/kusto_connection.py
+++ b/fabric_rti_mcp/services/kusto/kusto_connection.py
@@ -1,23 +1,12 @@
-import time
-from typing import Any
-
-from azure.core.credentials import AccessToken, TokenCredential
+from azure.core.credentials import TokenCredential
 from azure.identity import DefaultAzureCredential
 from azure.kusto.data import KustoClient, KustoConnectionStringBuilder
 from azure.kusto.ingest import KustoStreamingIngestClient
 
-from fabric_rti_mcp.authentication.auth_context import get_auth_token
+from fabric_rti_mcp.authentication.auth_context import BearerTokenCredential as BearerTokenCredential
+from fabric_rti_mcp.authentication.auth_context import get_auth_token as get_auth_token
+from fabric_rti_mcp.authentication.auth_context import get_azure_credential_or_http_header_token
 from fabric_rti_mcp.authentication.auth_context import set_auth_token as set_auth_token
-
-
-class BearerTokenCredential(TokenCredential):
-    """A credential that reads the bearer token from the current request's ContextVar on each call."""
-
-    def get_token(self, *scopes: str, **kwargs: Any) -> AccessToken:
-        token = get_auth_token()
-        if not token:
-            raise ValueError("No auth token available in request context")
-        return AccessToken(token=token, expires_on=int(time.time()) + 3600)
 
 
 class KustoConnection:
@@ -39,15 +28,12 @@ class KustoConnection:
         self.default_database = default_database
 
     def _get_credential(self, login_endpoint: str) -> TokenCredential:
-        # Check if we have a bearer token from HTTP auth
-        token = get_auth_token()
-        if token:
-            return BearerTokenCredential()
-
-        return DefaultAzureCredential(
-            exclude_shared_token_cache_credential=True,
-            exclude_interactive_browser_credential=False,
-            authority=login_endpoint,
+        return get_azure_credential_or_http_header_token(
+            lambda: DefaultAzureCredential(
+                exclude_shared_token_cache_credential=True,
+                exclude_interactive_browser_credential=False,
+                authority=login_endpoint,
+            )
         )
 
 

--- a/fabric_rti_mcp/services/kusto/kusto_connection.py
+++ b/fabric_rti_mcp/services/kusto/kusto_connection.py
@@ -1,5 +1,4 @@
 from azure.core.credentials import TokenCredential
-from azure.identity import DefaultAzureCredential
 from azure.kusto.data import KustoClient, KustoConnectionStringBuilder
 from azure.kusto.ingest import KustoStreamingIngestClient
 
@@ -28,13 +27,7 @@ class KustoConnection:
         self.default_database = default_database
 
     def _get_credential(self, login_endpoint: str) -> TokenCredential:
-        return get_azure_credential_or_http_header_token(
-            lambda: DefaultAzureCredential(
-                exclude_shared_token_cache_credential=True,
-                exclude_interactive_browser_credential=False,
-                authority=login_endpoint,
-            )
-        )
+        return get_azure_credential_or_http_header_token(authority=login_endpoint)
 
 
 def sanitize_uri(cluster_uri: str) -> str:

--- a/tests/unit/test_fabric_api_http_client.py
+++ b/tests/unit/test_fabric_api_http_client.py
@@ -56,32 +56,43 @@ def clear_auth_token() -> Generator[None, None, None]:
     set_auth_token(None)
 
 
+def mock_default_credential(monkeypatch: pytest.MonkeyPatch, credential: FakeCredential) -> MagicMock:
+    default_credential = MagicMock(return_value=credential)
+    monkeypatch.setattr("fabric_rti_mcp.authentication.auth_context.DefaultAzureCredential", default_credential)
+    return default_credential
+
+
 def test_get_headers_uses_request_token_without_default_credential(monkeypatch: pytest.MonkeyPatch) -> None:
     credential = FakeCredential()
-    monkeypatch.setattr(FabricAPIHttpClient, "_get_credential", lambda self: credential)
+    default_credential = mock_default_credential(monkeypatch, credential)
     client = FabricAPIHttpClient("https://fabric.example")
 
     set_auth_token("caller-token")
     headers = client._get_headers()
 
     assert headers["Authorization"] == "Bearer caller-token"
+    default_credential.assert_not_called()
     credential.get_token_mock.assert_not_called()
 
 
 def test_get_headers_falls_back_to_default_credential_without_request_token(monkeypatch: pytest.MonkeyPatch) -> None:
     credential = FakeCredential()
-    monkeypatch.setattr(FabricAPIHttpClient, "_get_credential", lambda self: credential)
+    default_credential = mock_default_credential(monkeypatch, credential)
     client = FabricAPIHttpClient("https://fabric.example")
 
     headers = client._get_headers()
 
     assert headers["Authorization"] == "Bearer managed-identity-token"
+    default_credential.assert_called_once_with(
+        exclude_shared_token_cache_credential=True,
+        exclude_interactive_browser_credential=False,
+    )
     credential.get_token_mock.assert_called_once_with("https://api.fabric.microsoft.com/.default")
 
 
 def test_extra_headers_cannot_override_request_authorization(monkeypatch: pytest.MonkeyPatch) -> None:
     credential = FakeCredential()
-    monkeypatch.setattr(FabricAPIHttpClient, "_get_credential", lambda self: credential)
+    default_credential = mock_default_credential(monkeypatch, credential)
     client = FabricAPIHttpClient("https://fabric.example")
 
     set_auth_token("caller-token")
@@ -89,12 +100,13 @@ def test_extra_headers_cannot_override_request_authorization(monkeypatch: pytest
 
     assert headers["Authorization"] == "Bearer caller-token"
     assert headers["x-ms-custom"] == "value"
+    default_credential.assert_not_called()
     credential.get_token_mock.assert_not_called()
 
 
 def test_make_request_preserves_request_token_when_running_inside_event_loop(monkeypatch: pytest.MonkeyPatch) -> None:
     credential = FakeCredential()
-    monkeypatch.setattr(FabricAPIHttpClient, "_get_credential", lambda self: credential)
+    default_credential = mock_default_credential(monkeypatch, credential)
     monkeypatch.setattr("fabric_rti_mcp.fabric_api_http_client.httpx.AsyncClient", FakeAsyncClient)
     client = FabricAPIHttpClient("https://fabric.example")
 
@@ -106,4 +118,5 @@ def test_make_request_preserves_request_token_when_running_inside_event_loop(mon
 
     assert result == {"ok": True}
     assert FakeAsyncClient.last_headers["Authorization"] == "Bearer caller-token"
+    default_credential.assert_not_called()
     credential.get_token_mock.assert_not_called()

--- a/tests/unit/test_fabric_api_http_client.py
+++ b/tests/unit/test_fabric_api_http_client.py
@@ -1,0 +1,101 @@
+import asyncio
+from collections.abc import Generator
+from types import TracebackType
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from fabric_rti_mcp.authentication.auth_context import set_auth_token
+from fabric_rti_mcp.fabric_api_http_client import FabricAPIHttpClient
+
+
+class FakeResponse:
+    status_code = 200
+    text = '{"ok": true}'
+
+    def json(self) -> dict[str, bool]:
+        return {"ok": True}
+
+
+class FakeAsyncClient:
+    last_headers: dict[str, str] = {}
+
+    def __init__(self, timeout: int) -> None:
+        self.timeout = timeout
+
+    async def __aenter__(self) -> "FakeAsyncClient":
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> None:
+        return None
+
+    async def get(self, url: str, headers: dict[str, str]) -> FakeResponse:
+        FakeAsyncClient.last_headers = headers
+        return FakeResponse()
+
+
+@pytest.fixture(autouse=True)
+def clear_auth_token() -> Generator[None, None, None]:
+    set_auth_token(None)
+    yield
+    set_auth_token(None)
+
+
+def test_get_headers_uses_request_token_without_default_credential(monkeypatch: pytest.MonkeyPatch) -> None:
+    credential = MagicMock()
+    monkeypatch.setattr(FabricAPIHttpClient, "_get_credential", lambda self: credential)
+    client = FabricAPIHttpClient("https://fabric.example")
+
+    set_auth_token("caller-token")
+    headers = client._get_headers()
+
+    assert headers["Authorization"] == "Bearer caller-token"
+    credential.get_token.assert_not_called()
+
+
+def test_get_headers_falls_back_to_default_credential_without_request_token(monkeypatch: pytest.MonkeyPatch) -> None:
+    credential = MagicMock()
+    credential.get_token.return_value = MagicMock(token="managed-identity-token", expires_on=123)
+    monkeypatch.setattr(FabricAPIHttpClient, "_get_credential", lambda self: credential)
+    client = FabricAPIHttpClient("https://fabric.example")
+
+    headers = client._get_headers()
+
+    assert headers["Authorization"] == "Bearer managed-identity-token"
+    credential.get_token.assert_called_once_with("https://api.fabric.microsoft.com/.default")
+
+
+def test_extra_headers_cannot_override_request_authorization(monkeypatch: pytest.MonkeyPatch) -> None:
+    credential = MagicMock()
+    monkeypatch.setattr(FabricAPIHttpClient, "_get_credential", lambda self: credential)
+    client = FabricAPIHttpClient("https://fabric.example")
+
+    set_auth_token("caller-token")
+    headers = client._get_headers({"Authorization": "Bearer attacker-token", "x-ms-custom": "value"})
+
+    assert headers["Authorization"] == "Bearer caller-token"
+    assert headers["x-ms-custom"] == "value"
+    credential.get_token.assert_not_called()
+
+
+def test_make_request_preserves_request_token_when_running_inside_event_loop(monkeypatch: pytest.MonkeyPatch) -> None:
+    credential = MagicMock()
+    monkeypatch.setattr(FabricAPIHttpClient, "_get_credential", lambda self: credential)
+    monkeypatch.setattr("fabric_rti_mcp.fabric_api_http_client.httpx.AsyncClient", FakeAsyncClient)
+    client = FabricAPIHttpClient("https://fabric.example")
+
+    async def run_request() -> dict[str, Any]:
+        set_auth_token("caller-token")
+        return client.make_request("GET", "/items")
+
+    result = asyncio.run(run_request())
+
+    assert result == {"ok": True}
+    assert FakeAsyncClient.last_headers["Authorization"] == "Bearer caller-token"
+    credential.get_token.assert_not_called()

--- a/tests/unit/test_fabric_api_http_client.py
+++ b/tests/unit/test_fabric_api_http_client.py
@@ -5,6 +5,7 @@ from typing import Any
 from unittest.mock import MagicMock
 
 import pytest
+from azure.core.credentials import AccessToken, TokenCredential
 
 from fabric_rti_mcp.authentication.auth_context import set_auth_token
 from fabric_rti_mcp.fabric_api_http_client import FabricAPIHttpClient
@@ -16,6 +17,14 @@ class FakeResponse:
 
     def json(self) -> dict[str, bool]:
         return {"ok": True}
+
+
+class FakeCredential(TokenCredential):
+    def __init__(self, token: str = "managed-identity-token") -> None:
+        self.get_token_mock = MagicMock(return_value=AccessToken(token=token, expires_on=123))
+
+    def get_token(self, *scopes: str, **kwargs: Any) -> AccessToken:
+        return self.get_token_mock(*scopes, **kwargs)
 
 
 class FakeAsyncClient:
@@ -48,7 +57,7 @@ def clear_auth_token() -> Generator[None, None, None]:
 
 
 def test_get_headers_uses_request_token_without_default_credential(monkeypatch: pytest.MonkeyPatch) -> None:
-    credential = MagicMock()
+    credential = FakeCredential()
     monkeypatch.setattr(FabricAPIHttpClient, "_get_credential", lambda self: credential)
     client = FabricAPIHttpClient("https://fabric.example")
 
@@ -56,23 +65,22 @@ def test_get_headers_uses_request_token_without_default_credential(monkeypatch: 
     headers = client._get_headers()
 
     assert headers["Authorization"] == "Bearer caller-token"
-    credential.get_token.assert_not_called()
+    credential.get_token_mock.assert_not_called()
 
 
 def test_get_headers_falls_back_to_default_credential_without_request_token(monkeypatch: pytest.MonkeyPatch) -> None:
-    credential = MagicMock()
-    credential.get_token.return_value = MagicMock(token="managed-identity-token", expires_on=123)
+    credential = FakeCredential()
     monkeypatch.setattr(FabricAPIHttpClient, "_get_credential", lambda self: credential)
     client = FabricAPIHttpClient("https://fabric.example")
 
     headers = client._get_headers()
 
     assert headers["Authorization"] == "Bearer managed-identity-token"
-    credential.get_token.assert_called_once_with("https://api.fabric.microsoft.com/.default")
+    credential.get_token_mock.assert_called_once_with("https://api.fabric.microsoft.com/.default")
 
 
 def test_extra_headers_cannot_override_request_authorization(monkeypatch: pytest.MonkeyPatch) -> None:
-    credential = MagicMock()
+    credential = FakeCredential()
     monkeypatch.setattr(FabricAPIHttpClient, "_get_credential", lambda self: credential)
     client = FabricAPIHttpClient("https://fabric.example")
 
@@ -81,11 +89,11 @@ def test_extra_headers_cannot_override_request_authorization(monkeypatch: pytest
 
     assert headers["Authorization"] == "Bearer caller-token"
     assert headers["x-ms-custom"] == "value"
-    credential.get_token.assert_not_called()
+    credential.get_token_mock.assert_not_called()
 
 
 def test_make_request_preserves_request_token_when_running_inside_event_loop(monkeypatch: pytest.MonkeyPatch) -> None:
-    credential = MagicMock()
+    credential = FakeCredential()
     monkeypatch.setattr(FabricAPIHttpClient, "_get_credential", lambda self: credential)
     monkeypatch.setattr("fabric_rti_mcp.fabric_api_http_client.httpx.AsyncClient", FakeAsyncClient)
     client = FabricAPIHttpClient("https://fabric.example")
@@ -98,4 +106,4 @@ def test_make_request_preserves_request_token_when_running_inside_event_loop(mon
 
     assert result == {"ok": True}
     assert FakeAsyncClient.last_headers["Authorization"] == "Bearer caller-token"
-    credential.get_token.assert_not_called()
+    credential.get_token_mock.assert_not_called()

--- a/tests/unit/test_kusto_connection.py
+++ b/tests/unit/test_kusto_connection.py
@@ -53,22 +53,44 @@ class TestAuthTokenContextVar:
 
 
 class TestAzureCredentialOrHttpHeaderToken:
-    def test_uses_http_header_token_when_present(self) -> None:
+    def test_uses_http_header_token_when_present(self, monkeypatch: pytest.MonkeyPatch) -> None:
         set_auth_token("caller-token")
-        azure_credential_factory = MagicMock()
+        default_credential = MagicMock()
+        monkeypatch.setattr("fabric_rti_mcp.authentication.auth_context.DefaultAzureCredential", default_credential)
 
-        credential = get_azure_credential_or_http_header_token(azure_credential_factory)
+        credential = get_azure_credential_or_http_header_token()
 
         assert isinstance(credential, BearerTokenCredential)
         assert credential.get_token("scope").token == "caller-token"
-        azure_credential_factory.assert_not_called()
+        default_credential.assert_not_called()
 
-    def test_calls_azure_credential_factory_without_http_header_token(self) -> None:
+    def test_falls_back_to_default_azure_credential_without_http_header_token(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         set_auth_token(None)
         azure_credential = MagicMock()
-        azure_credential_factory = MagicMock(return_value=azure_credential)
+        default_credential = MagicMock(return_value=azure_credential)
+        monkeypatch.setattr("fabric_rti_mcp.authentication.auth_context.DefaultAzureCredential", default_credential)
 
-        credential = get_azure_credential_or_http_header_token(azure_credential_factory)
+        credential = get_azure_credential_or_http_header_token()
 
         assert credential is azure_credential
-        azure_credential_factory.assert_called_once_with()
+        default_credential.assert_called_once_with(
+            exclude_shared_token_cache_credential=True,
+            exclude_interactive_browser_credential=False,
+        )
+
+    def test_passes_authority_to_default_azure_credential(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        set_auth_token(None)
+        azure_credential = MagicMock()
+        default_credential = MagicMock(return_value=azure_credential)
+        monkeypatch.setattr("fabric_rti_mcp.authentication.auth_context.DefaultAzureCredential", default_credential)
+
+        credential = get_azure_credential_or_http_header_token(authority="https://login.example")
+
+        assert credential is azure_credential
+        default_credential.assert_called_once_with(
+            exclude_shared_token_cache_credential=True,
+            exclude_interactive_browser_credential=False,
+            authority="https://login.example",
+        )

--- a/tests/unit/test_kusto_connection.py
+++ b/tests/unit/test_kusto_connection.py
@@ -63,10 +63,12 @@ class TestAzureCredentialOrHttpHeaderToken:
         assert credential.get_token("scope").token == "caller-token"
         azure_credential_factory.assert_not_called()
 
-    def test_falls_back_to_azure_credential_without_http_header_token(self) -> None:
+    def test_calls_azure_credential_factory_without_http_header_token(self) -> None:
         set_auth_token(None)
         azure_credential = MagicMock()
+        azure_credential_factory = MagicMock(return_value=azure_credential)
 
-        credential = get_azure_credential_or_http_header_token(lambda: azure_credential)
+        credential = get_azure_credential_or_http_header_token(azure_credential_factory)
 
         assert credential is azure_credential
+        azure_credential_factory.assert_called_once_with()

--- a/tests/unit/test_kusto_connection.py
+++ b/tests/unit/test_kusto_connection.py
@@ -1,3 +1,8 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+from fabric_rti_mcp.authentication.auth_context import get_azure_credential_or_http_header_token
 from fabric_rti_mcp.services.kusto.kusto_connection import BearerTokenCredential, get_auth_token, set_auth_token
 
 
@@ -19,11 +24,8 @@ class TestBearerTokenCredential:
     def test_raises_when_no_token_in_context(self) -> None:
         set_auth_token(None)
         cred = BearerTokenCredential()
-        try:
+        with pytest.raises(ValueError, match="No auth token"):
             cred.get_token("scope")
-            assert False, "Expected ValueError"
-        except ValueError as e:
-            assert "No auth token" in str(e)
 
     def test_token_not_stale_after_context_change(self) -> None:
         """Simulates the exact bug from issue #128."""
@@ -48,3 +50,23 @@ class TestAuthTokenContextVar:
     def test_default_is_none(self) -> None:
         set_auth_token(None)
         assert get_auth_token() is None
+
+
+class TestAzureCredentialOrHttpHeaderToken:
+    def test_uses_http_header_token_when_present(self) -> None:
+        set_auth_token("caller-token")
+        azure_credential_factory = MagicMock()
+
+        credential = get_azure_credential_or_http_header_token(azure_credential_factory)
+
+        assert isinstance(credential, BearerTokenCredential)
+        assert credential.get_token("scope").token == "caller-token"
+        azure_credential_factory.assert_not_called()
+
+    def test_falls_back_to_azure_credential_without_http_header_token(self) -> None:
+        set_auth_token(None)
+        azure_credential = MagicMock()
+
+        credential = get_azure_credential_or_http_header_token(lambda: azure_credential)
+
+        assert credential is azure_credential


### PR DESCRIPTION
## Summary
- use the current HTTP request bearer token for Fabric API calls when one is present
- keep DefaultAzureCredential fallback for local/stdio usage without a caller token
- add shared `get_azure_credential_or_http_header_token` credential selection used by both Kusto and FabricAPIHttpClient
- create DefaultAzureCredential inside the shared helper, with optional authority for Kusto login endpoints
- move request auth token storage into a shared auth context and reset it after HTTP requests
- preserve request context across the sync-to-async thread hop in FabricAPIHttpClient
- add unit coverage for caller-token auth, local fallback, authorization header protection, event-loop/thread propagation, and the shared credential selector

## Validation
- `ruff check fabric_rti_mcp tests\unit\test_fabric_api_http_client.py tests\unit\test_kusto_connection.py`
- `ty check fabric_rti_mcp`
- `python -m pytest`