### PR TITLE
Add OBO support to FabricAPIHttpClient (Fixes #179)

### DIFF
--- a/fabric_rti_mcp/authentication/auth_middleware.py
+++ b/fabric_rti_mcp/authentication/auth_middleware.py
@@ -17,6 +17,7 @@ from fabric_rti_mcp.authentication.token_obo_exchanger import TokenOboExchanger
 from fabric_rti_mcp.config import global_config as config
 from fabric_rti_mcp.config import logger
 from fabric_rti_mcp.config.obo import obo_config
+from fabric_rti_mcp.fabric_api_http_client import set_fabric_auth_token
 from fabric_rti_mcp.services.kusto.kusto_connection import set_auth_token
 
 # Secure asymmetric algorithms allowed for JWT validation.
@@ -209,6 +210,9 @@ class AuthMiddleware(BaseHTTPMiddleware):
             try:
                 if config.use_obo_flow:
                     logger.info("Started performing OBO token exchange")
+                    # Capture the original user assertion before any exchange overwrites
+                    # the `token` variable below; the Fabric exchange needs the original.
+                    user_assertion = token
                     # Create token exchanger and perform OBO token exchange
                     token_exchanger = TokenOboExchanger()
                     exchanged_token = await token_exchanger.perform_obo_token_exchange(
@@ -216,6 +220,13 @@ class AuthMiddleware(BaseHTTPMiddleware):
                     )
                     # Update token to use the exchanged token
                     token = exchanged_token
+                    # Second exchange for the Fabric REST audience; stashed in a
+                    # separate ContextVar so FabricAPIHttpClient can pick it up
+                    # without disturbing the Kusto path.
+                    fabric_token = await token_exchanger.perform_obo_token_exchange(
+                        user_token=user_assertion, resource_uri=obo_config.fabric_audience
+                    )
+                    set_fabric_auth_token(fabric_token)
                     logger.info("Successfully performed OBO token exchange")
                 else:
                     logger.info("OBO flow not enabled; using original token")

--- a/fabric_rti_mcp/config/obo.py
+++ b/fabric_rti_mcp/config/obo.py
@@ -12,6 +12,7 @@ class FabricRtiMcpOBOFlowEnvVarNames:
     # user assigned managed identity client id used as Federated credentials on the Entra App (entra_app_client_id)
     umi_client_id = "FABRIC_RTI_MCP_USER_MANAGED_IDENTITY_CLIENT_ID"
     kusto_audience = "FABRIC_RTI_MCP_KUSTO_AUDIENCE"  # Kusto audience, ex: https://<clustername>.kusto.windows.net
+    fabric_audience = "FABRIC_RTI_MCP_FABRIC_AUDIENCE"  # Fabric REST audience, ex: https://api.fabric.microsoft.com
 
 
 # Default values for OBO Flow configuration
@@ -19,6 +20,7 @@ DEFAULT_FABRIC_RTI_MCP_AZURE_TENANT_ID = "72f988bf-86f1-41af-91ab-2d7cd011db47" 
 DEFAULT_FABRIC_RTI_MCP_ENTRA_APP_CLIENT_ID = ""
 DEFAULT_FABRIC_RTI_MCP_USER_MANAGED_IDENTITY_CLIENT_ID = ""
 DEFAULT_FABRIC_RTI_MCP_KUSTO_AUDIENCE = "https://kusto.kusto.windows.net"
+DEFAULT_FABRIC_RTI_MCP_FABRIC_AUDIENCE = "https://api.fabric.microsoft.com"
 
 
 @dataclass(slots=True, frozen=True)
@@ -29,6 +31,7 @@ class FabricRtiMcpOBOFlowAuthConfig:
     entra_app_client_id: str
     umi_client_id: str
     kusto_audience: str
+    fabric_audience: str
 
     @staticmethod
     def from_env() -> "FabricRtiMcpOBOFlowAuthConfig":
@@ -46,6 +49,9 @@ class FabricRtiMcpOBOFlowAuthConfig:
             kusto_audience=os.getenv(
                 FabricRtiMcpOBOFlowEnvVarNames.kusto_audience, DEFAULT_FABRIC_RTI_MCP_KUSTO_AUDIENCE
             ),
+            fabric_audience=os.getenv(
+                FabricRtiMcpOBOFlowEnvVarNames.fabric_audience, DEFAULT_FABRIC_RTI_MCP_FABRIC_AUDIENCE
+            ),
         )
 
     @staticmethod
@@ -57,6 +63,7 @@ class FabricRtiMcpOBOFlowAuthConfig:
             FabricRtiMcpOBOFlowEnvVarNames.entra_app_client_id,
             FabricRtiMcpOBOFlowEnvVarNames.umi_client_id,
             FabricRtiMcpOBOFlowEnvVarNames.kusto_audience,
+            FabricRtiMcpOBOFlowEnvVarNames.fabric_audience,
         ]
         for env_var in env_vars:
             if os.getenv(env_var) is not None:
@@ -83,6 +90,7 @@ class FabricRtiMcpOBOFlowAuthConfig:
             entra_app_client_id=entra_app_client_id,
             umi_client_id=umi_client_id,
             kusto_audience=obo_config.kusto_audience,
+            fabric_audience=obo_config.fabric_audience,
         )
 
 

--- a/fabric_rti_mcp/fabric_api_http_client.py
+++ b/fabric_rti_mcp/fabric_api_http_client.py
@@ -1,11 +1,37 @@
 import asyncio
 from collections.abc import Coroutine
+from contextvars import ContextVar
 from typing import Any, cast
 
 import httpx
 from azure.identity import ChainedTokenCredential, DefaultAzureCredential
 
 from fabric_rti_mcp.config import GlobalFabricRTIConfig, logger
+
+# Per-request Fabric token, set by AuthMiddleware after OBO exchange.
+# Mirrors the ContextVar pattern in
+# ``fabric_rti_mcp.services.kusto.kusto_connection`` so the Fabric REST path
+# can honor per-user delegation in gateway scenarios where many users share
+# a single ``FabricAPIHttpClient`` instance (cf. ``FabricHttpClientCache``).
+_fabric_user_token: ContextVar[str | None] = ContextVar("_fabric_user_token", default=None)
+
+
+def set_fabric_auth_token(token: str | None) -> None:
+    """Set a pre-exchanged Fabric token for the current request context.
+
+    The value is the Fabric-scoped access token already obtained via OBO by
+    the ``AuthMiddleware`` — NOT the inbound user assertion. The HTTP
+    client treats it as opaque and forwards it as the ``Authorization``
+    bearer for any request issued within this async context.
+
+    Async-safe via ``ContextVar``; clear by passing ``None``.
+    """
+    _fabric_user_token.set(token)
+
+
+def get_fabric_auth_token() -> str | None:
+    """Return the Fabric token set for the current request context, if any."""
+    return _fabric_user_token.get()
 
 
 class FabricAPIHttpClient:
@@ -47,6 +73,15 @@ class FabricAPIHttpClient:
         )
 
     def _get_access_token(self) -> str:
+        # Prefer a per-request OBO-exchanged Fabric token if AuthMiddleware
+        # has stashed one for the current request context. Falls back to the
+        # host's DefaultAzureCredential chain otherwise — same behavior as
+        # before this seam existed.
+        fabric_token = get_fabric_auth_token()
+        if fabric_token is not None:
+            logger.debug("Using OBO-exchanged Fabric token from request context")
+            return fabric_token
+
         try:
             # Get token from Azure credential
             token = self.credential.get_token(self.token_scope)

--- a/tests/unit/test_fabric_api_http_client.py
+++ b/tests/unit/test_fabric_api_http_client.py
@@ -1,0 +1,72 @@
+import contextvars
+from unittest.mock import Mock
+
+from fabric_rti_mcp.fabric_api_http_client import (
+    FabricAPIHttpClient,
+    get_fabric_auth_token,
+    set_fabric_auth_token,
+)
+
+
+class TestFabricAuthTokenContextVar:
+    def test_set_and_get(self) -> None:
+        set_fabric_auth_token("my-fabric-token")
+        assert get_fabric_auth_token() == "my-fabric-token"
+
+    def test_default_is_none(self) -> None:
+        set_fabric_auth_token(None)
+        assert get_fabric_auth_token() is None
+
+    def test_isolation_via_copy_context(self) -> None:
+        """ContextVar must scope per request-context.
+
+        asyncio.create_task() copies the current context; mutations inside
+        a task do not leak back to the parent. We verify that property
+        synchronously here using contextvars.copy_context(), which is the
+        same mechanism asyncio uses under the hood.
+        """
+        set_fabric_auth_token("outer")
+        captured: list[str | None] = []
+
+        def in_copy() -> None:
+            # Inside a copied context, set a different value.
+            set_fabric_auth_token("inner")
+            captured.append(get_fabric_auth_token())
+
+        contextvars.copy_context().run(in_copy)
+
+        # Child saw its own value.
+        assert captured == ["inner"]
+        # Parent context unchanged by the child's write.
+        assert get_fabric_auth_token() == "outer"
+
+
+class TestAccessTokenShortCircuit:
+    """_get_access_token must prefer the ContextVar's pre-exchanged token
+    over the cached self.credential. Without this, every request would
+    fall through to DefaultAzureCredential and per-user delegation would
+    be lost.
+    """
+
+    def test_uses_contextvar_when_set(self) -> None:
+        set_fabric_auth_token("ctx-fabric-token")
+        client = FabricAPIHttpClient(api_base_url="https://example.test/v1")
+
+        # If the short-circuit fails, this would call into self.credential.
+        # Replacing it with a Mock that fails ensures we see the bug if
+        # the short-circuit regresses.
+        client.credential = Mock(  # ty: ignore[invalid-assignment]
+            get_token=Mock(side_effect=AssertionError("credential should not be consulted"))
+        )
+
+        assert client._get_access_token() == "ctx-fabric-token"
+
+    def test_falls_back_to_credential_when_unset(self) -> None:
+        set_fabric_auth_token(None)
+        client = FabricAPIHttpClient(api_base_url="https://example.test/v1")
+
+        mock_token = Mock(token="default-credential-token", expires_on=9999999999)
+        client.credential = Mock(get_token=Mock(return_value=mock_token))  # ty: ignore[invalid-assignment]
+
+        assert client._get_access_token() == "default-credential-token"
+        client.credential.get_token.assert_called_once_with("https://api.fabric.microsoft.com/.default")


### PR DESCRIPTION
## What

Adds a `ContextVar`-based seam to `FabricAPIHttpClient` so `AuthMiddleware` can thread an OBO-exchanged Fabric token through to the credential layer. Mirrors the existing pattern in `services/kusto/kusto_connection.py`.

## Why

Today `FabricAPIHttpClient` uses `DefaultAzureCredential` unconditionally. Any deployment that fronts `microsoft-fabric-rti-mcp` behind a gateway (context in #179) loses per-user delegation: Eventstream, Activator, and Map tools execute as the gateway's local identity rather than the requesting user.

## How

Three commits for reviewability:

1. **`Add OBO ContextVar seam to FabricAPIHttpClient`** — adds `_fabric_user_token` ContextVar with `set_fabric_auth_token` / `get_fabric_auth_token` helpers. `_get_access_token()` short-circuits to the ContextVar value when set, falls back to the existing `DefaultAzureCredential` path otherwise. No new credential wrapper class — the access-token layer returns a string directly, so the ContextVar can carry the already-exchanged token without needing a `TokenCredential` adapter. This also sidesteps a latent concurrency issue: `FabricAPIHttpClient` caches `self.credential` at `__init__` and `FabricHttpClientCache` holds a singleton, so a credential-factory-based switch would only fire on the first request. Short-circuiting at the access-token layer is safe across concurrent requests.

2. **`Exchange Fabric-audience token in AuthMiddleware`** — when `use_obo_flow` is enabled, performs a second OBO exchange targeting the Fabric REST audience and stashes the result via `set_fabric_auth_token`. The existing Kusto exchange is untouched; the Fabric exchange runs after it using a captured copy of the original user assertion (since the existing code reassigns `token` to the Kusto-scoped result). Adds a `fabric_audience` field to `FabricRtiMcpOBOFlowAuthConfig` mirroring `kusto_audience`: configurable via `FABRIC_RTI_MCP_FABRIC_AUDIENCE`, defaulted to `https://api.fabric.microsoft.com`.

3. **`Add unit tests for Fabric OBO ContextVar + short-circuit`** — 5 new tests covering the round-trip, default-None behavior, per-context isolation via `contextvars.copy_context()`, the short-circuit, and the fallback. Mirrors the style of `tests/unit/test_kusto_connection.py`. Synchronous (no `pytest-asyncio` dep needed) — `copy_context()` is the same mechanism `asyncio.create_task()` uses internally.

## Tested

- `make ci` locally:
  - `ruff format --check fabric_rti_mcp` — clean
  - `ruff check fabric_rti_mcp` — clean
  - `ty check fabric_rti_mcp` — same diagnostic count as the unchanged baseline (36 in 9 files, none of them files touched by this PR)
  - `pytest` — 175 pass (170 baseline + 5 new)
- Existing tests unchanged; no regressions.

## Follow-ups (not in this PR)

- `perform_obo_token_exchange` returns only the token string; MSAL's `expires_in` is dropped. Not a problem today because `_get_access_token` returns a string and the SDK handles its own caching, but if a future credential-style consumer wants `AccessToken.expires_on`, surfacing `expires_in` from the exchanger would be a cleaner API. Happy to send a separate PR for that if there's interest.

## Notes

- No new runtime dependencies.
- No public-API churn — `set_fabric_auth_token` is analogous to the long-standing `set_auth_token` in `kusto_connection`.
- Draft PR: feedback welcome on whether this is the shape the maintainers want before further polish.

Fixes #179.
