### PR TITLE
CI: bump CodeQL Action v2->v3 and checkout v3->v4

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -38,11 +38,11 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@v3
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -56,7 +56,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v2
+      uses: github/codeql-action/autobuild@v3
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
@@ -69,4 +69,4 @@ jobs:
     #   ./location_of_script_within_repo/buildscript.sh
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@v3


### PR DESCRIPTION
CodeQL Action **v2** and **actions/checkout@v3** (Node 16) are both deprecated by GitHub and emit deprecation warnings on every CodeQL run; v2 is on the end-of-life track.

This bumps `init` / `autobuild` / `analyze` to `@v3` and `checkout` to `@v4` in `codeql-analysis.yml`. Version-only change — same Python analysis, just current action majors on a Node 20 runner. CI on this PR exercises it.

Spotted while contributing #181. No open PR touches `codeql-analysis.yml` (the `copilot/fix-github-actions-workflow*` branches don't address this), so filing as a small standalone housekeeping change.