### PR TITLE
Add kusto_show_command MCP tool

### DIFF
--- a/fabric_rti_mcp/services/kusto/kusto_service.py
+++ b/fabric_rti_mcp/services/kusto/kusto_service.py
@@ -633,6 +633,34 @@ def kusto_command(
     return _execute(command, cluster_uri, database=database, client_request_properties=client_request_properties)
 
 
+def kusto_command_readonly(
+    command: str,
+    cluster_uri: str,
+    database: str | None = None,
+    client_request_properties: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """
+    Executes a read-only Kusto management command (.show) on the specified database.
+    If no database is provided, it will use the default database.
+
+    This tool is restricted to .show commands only. For mutating commands
+    (.create, .alter, .drop, .set, .delete, etc.), use kusto_command instead.
+
+    :param command: The read-only kusto management command to execute (must be a .show command).
+    :param cluster_uri: The URI of the Kusto cluster.
+    :param database: Optional database name. If not provided, uses the default database.
+    :param client_request_properties: Optional dictionary of additional client request properties.
+    :return: The result of the command execution as a list of dictionaries (json).
+    """
+    first_stmt = _find_first_statement(command)
+    if not first_stmt.startswith(".show "):
+        raise ValueError(
+            "kusto_command_readonly only supports read-only .show commands. "
+            "For mutating commands (.create, .alter, .drop, etc.), use kusto_command instead."
+        )
+    return _execute(command, cluster_uri, database=database, client_request_properties=client_request_properties)
+
+
 def kusto_list_entities(
     cluster_uri: str,
     entity_type: str,

--- a/fabric_rti_mcp/services/kusto/kusto_service.py
+++ b/fabric_rti_mcp/services/kusto/kusto_service.py
@@ -633,20 +633,19 @@ def kusto_command(
     return _execute(command, cluster_uri, database=database, client_request_properties=client_request_properties)
 
 
-def kusto_command_readonly(
+def kusto_show_command(
     command: str,
     cluster_uri: str,
     database: str | None = None,
     client_request_properties: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     """
-    Executes a read-only Kusto management command (.show) on the specified database.
+    Executes a Kusto .show management command on the specified database.
     If no database is provided, it will use the default database.
 
-    This tool is restricted to .show commands only. For mutating commands
-    (.create, .alter, .drop, .set, .delete, etc.), use kusto_command instead.
+    Only .show commands are accepted.
 
-    :param command: The read-only kusto management command to execute (must be a .show command).
+    :param command: The .show command to execute.
     :param cluster_uri: The URI of the Kusto cluster.
     :param database: Optional database name. If not provided, uses the default database.
     :param client_request_properties: Optional dictionary of additional client request properties.
@@ -655,7 +654,7 @@ def kusto_command_readonly(
     first_stmt = _find_first_statement(command)
     if not first_stmt.startswith(".show "):
         raise ValueError(
-            "kusto_command_readonly only supports read-only .show commands. "
+            "kusto_show_command only supports read-only .show commands. "
             "For mutating commands (.create, .alter, .drop, etc.), use kusto_command instead."
         )
     return _execute(command, cluster_uri, database=database, client_request_properties=client_request_properties)

--- a/fabric_rti_mcp/services/kusto/kusto_tools.py
+++ b/fabric_rti_mcp/services/kusto/kusto_tools.py
@@ -18,6 +18,10 @@ def register_tools(mcp: FastMCP) -> None:
         annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=True),
     )
     mcp.add_tool(
+        kusto_service.kusto_command_readonly,
+        annotations=ToolAnnotations(readOnlyHint=True, destructiveHint=False),
+    )
+    mcp.add_tool(
         kusto_service.kusto_list_entities,
         annotations=ToolAnnotations(readOnlyHint=True, destructiveHint=False),
     )

--- a/fabric_rti_mcp/services/kusto/kusto_tools.py
+++ b/fabric_rti_mcp/services/kusto/kusto_tools.py
@@ -18,7 +18,7 @@ def register_tools(mcp: FastMCP) -> None:
         annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=True),
     )
     mcp.add_tool(
-        kusto_service.kusto_command_readonly,
+        kusto_service.kusto_show_command,
         annotations=ToolAnnotations(readOnlyHint=True, destructiveHint=False),
     )
     mcp.add_tool(

--- a/tests/unit/kusto/test_kql_escape.py
+++ b/tests/unit/kusto/test_kql_escape.py
@@ -5,7 +5,7 @@ from fabric_rti_mcp.services.kusto.kusto_service import (
     kql_escape_entity_name,
     kql_escape_string,
     kusto_command,
-    kusto_command_readonly,
+    kusto_show_command,
     kusto_query,
 )
 
@@ -190,7 +190,7 @@ class TestQueryCommandValidation:
         assert result["format"] == "kusto_response"
 
 
-class TestCommandReadonlyValidation:
+class TestShowCommandValidation:
     @pytest.mark.parametrize(
         "command",
         [
@@ -206,7 +206,7 @@ class TestCommandReadonlyValidation:
     )
     def test_rejects_non_show_commands(self, command: str) -> None:
         with pytest.raises(ValueError, match="read-only .show commands"):
-            kusto_command_readonly(command, "https://help.kusto.windows.net")
+            kusto_show_command(command, "https://help.kusto.windows.net")
 
     @pytest.mark.parametrize(
         "command",
@@ -235,5 +235,5 @@ class TestCommandReadonlyValidation:
         connection.default_database = "db"
         mock_conn.return_value = connection
 
-        result = kusto_command_readonly(command, "https://help.kusto.windows.net")
+        result = kusto_show_command(command, "https://help.kusto.windows.net")
         assert result["format"] == "kusto_response"

--- a/tests/unit/kusto/test_kql_escape.py
+++ b/tests/unit/kusto/test_kql_escape.py
@@ -5,6 +5,7 @@ from fabric_rti_mcp.services.kusto.kusto_service import (
     kql_escape_entity_name,
     kql_escape_string,
     kusto_command,
+    kusto_command_readonly,
     kusto_query,
 )
 
@@ -186,4 +187,53 @@ class TestQueryCommandValidation:
         mock_conn.return_value = connection
 
         result = kusto_command("set notruncation;\n.show tables", "https://help.kusto.windows.net")
+        assert result["format"] == "kusto_response"
+
+
+class TestCommandReadonlyValidation:
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "StormEvents | take 10",
+            ".create table T (col:string)",
+            ".alter table T (col:string)",
+            ".drop table T",
+            ".set-or-append T <| print 1",
+            ".delete table T records <| T",
+            ".rename table T to T2",
+            ".ingest into table T <| print 1",
+        ],
+    )
+    def test_rejects_non_show_commands(self, command: str) -> None:
+        with pytest.raises(ValueError, match="read-only .show commands"):
+            kusto_command_readonly(command, "https://help.kusto.windows.net")
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            ".show tables",
+            ".show tables | where TableName has 'Storm'",
+            ".show databases",
+            ".show cluster",
+            ".show version",
+            "set notruncation;\n.show tables",
+            "// comment\n.show tables",
+        ],
+    )
+    @patch("fabric_rti_mcp.services.kusto.kusto_service.CONFIG")
+    @patch("fabric_rti_mcp.services.kusto.kusto_service.get_kusto_connection")
+    def test_accepts_valid_show_commands(
+        self, mock_conn: MagicMock, mock_config: MagicMock, mock_kusto_response, command: str
+    ) -> None:
+        mock_config.response_format = "kusto_response"
+        mock_config.timeout_seconds = None
+        mock_config.offload_enabled = False
+        mock_client = MagicMock()
+        mock_client.execute.return_value = mock_kusto_response
+        connection = MagicMock()
+        connection.query_client = mock_client
+        connection.default_database = "db"
+        mock_conn.return_value = connection
+
+        result = kusto_command_readonly(command, "https://help.kusto.windows.net")
         assert result["format"] == "kusto_response"

--- a/tests/unit/kusto/test_kusto_service.py
+++ b/tests/unit/kusto/test_kusto_service.py
@@ -10,6 +10,7 @@ from fabric_rti_mcp.services.kusto.kusto_config import KustoConfig
 from fabric_rti_mcp.services.kusto.kusto_service import (
     KustoConnectionManager,
     kusto_command,
+    kusto_command_readonly,
     kusto_diagnostics,
     kusto_query,
     kusto_show_queryplan,
@@ -325,6 +326,36 @@ def test_blocked_crp_keys_raise_error(
         kusto_query(
             "T | take 1", sample_cluster_uri, database="db", client_request_properties={"Request_Readonly": False}
         )
+
+
+@patch("fabric_rti_mcp.services.kusto.kusto_service.CONFIG")
+@patch("fabric_rti_mcp.services.kusto.kusto_service.get_kusto_connection")
+def test_command_readonly_crp(
+    mock_get_kusto_connection: Mock,
+    mock_config: MagicMock,
+    sample_cluster_uri: str,
+    mock_kusto_response: KustoResponseDataSet,
+) -> None:
+    """Test that kusto_command_readonly enforces server-side readonly via CRP flags."""
+    mock_config.response_format = "kusto_response"
+    mock_config.timeout_seconds = None
+    mock_config.offload_enabled = False
+
+    mock_client = MagicMock()
+    mock_client.execute.return_value = mock_kusto_response
+
+    mock_connection = MagicMock()
+    mock_connection.query_client = mock_client
+    mock_connection.default_database = "default_db"
+    mock_get_kusto_connection.return_value = mock_connection
+
+    kusto_command_readonly(".show tables", sample_cluster_uri, database="test_db")
+
+    # Verify the CRP passed to execute has request_readonly set
+    crp = mock_client.execute.call_args[0][2]
+    assert isinstance(crp, ClientRequestProperties)
+    assert crp.has_option("request_readonly")
+    assert crp.client_request_id.startswith("KFRTI_MCP.kusto_command_readonly:")  # type: ignore
 
 
 @patch("fabric_rti_mcp.services.kusto.kusto_service.get_kusto_connection")

--- a/tests/unit/kusto/test_kusto_service.py
+++ b/tests/unit/kusto/test_kusto_service.py
@@ -10,7 +10,7 @@ from fabric_rti_mcp.services.kusto.kusto_config import KustoConfig
 from fabric_rti_mcp.services.kusto.kusto_service import (
     KustoConnectionManager,
     kusto_command,
-    kusto_command_readonly,
+    kusto_show_command,
     kusto_diagnostics,
     kusto_query,
     kusto_show_queryplan,
@@ -330,13 +330,13 @@ def test_blocked_crp_keys_raise_error(
 
 @patch("fabric_rti_mcp.services.kusto.kusto_service.CONFIG")
 @patch("fabric_rti_mcp.services.kusto.kusto_service.get_kusto_connection")
-def test_command_readonly_crp(
+def test_show_command_crp(
     mock_get_kusto_connection: Mock,
     mock_config: MagicMock,
     sample_cluster_uri: str,
     mock_kusto_response: KustoResponseDataSet,
 ) -> None:
-    """Test that kusto_command_readonly enforces server-side readonly via CRP flags."""
+    """Test that kusto_show_command enforces server-side readonly via CRP flags."""
     mock_config.response_format = "kusto_response"
     mock_config.timeout_seconds = None
     mock_config.offload_enabled = False
@@ -349,13 +349,13 @@ def test_command_readonly_crp(
     mock_connection.default_database = "default_db"
     mock_get_kusto_connection.return_value = mock_connection
 
-    kusto_command_readonly(".show tables", sample_cluster_uri, database="test_db")
+    kusto_show_command(".show tables", sample_cluster_uri, database="test_db")
 
     # Verify the CRP passed to execute has request_readonly set
     crp = mock_client.execute.call_args[0][2]
     assert isinstance(crp, ClientRequestProperties)
     assert crp.has_option("request_readonly")
-    assert crp.client_request_id.startswith("KFRTI_MCP.kusto_command_readonly:")  # type: ignore
+    assert crp.client_request_id.startswith("KFRTI_MCP.kusto_show_command:")  # type: ignore
 
 
 @patch("fabric_rti_mcp.services.kusto.kusto_service.get_kusto_connection")


### PR DESCRIPTION
**Problem**

Currently, MCP clients must route all management commands through `kusto_command`, which is annotated with `destructiveHint=True`. This means every `.show` command (read-only by nature) requires explicit user approval - creating friction during diagnostic and exploration workflows.

**Solution**

Add a new `kusto_show_command` tool that accepts only `.show` management commands and is annotated with `readOnlyHint=True, destructiveHint=False`, allowing MCP clients to auto-approve without user confirmation.

**Eval**
To validate this change doesn't confuse the LLM's tool selection, I used a tool selection eval. 
It sends 71 user prompts to a LLM with the full set of Kusto MCP tool schemas, and checks whether the model picks the right tool for each prompt. Prompts cover both explicit commands (e.g. `.show tables`, `.drop table Foo`) and plain English requests (e.g. "What tables exist?", "Drop the TempData table"). The eval runs twice - once with `kusto_show_command` in the tool list, once without - to measure whether adding the new tool causes any regressions.

Results (71 prompts, gpt-5.4):
- When users type explicit `.show` commands (e.g. `.show tables`), the model routes to `kusto_show_command` 100% of the time
- When users describe what they want in plain English (e.g. "Show the retention policy"), the model routes correctly 86% of the time
- Zero regression on mutating commands, queries, and all other tool categories
 Overall accuracy: 77% with the new tool vs 79% without - the 2% gap is noise, driven by a pre-existing issue where the `kusto_get_shots` tool description is too aggressive and steals unrelated prompts


[More about the evaluation](https://github.com/microsoft/fabric-rti-mcp/commit/3174cc98f123266b3f916151144cad418100e291#diff-f5cc3acd579560ec3f116d42e92db968cdbe1e491b7ec3a19a9a234e046c8864R189-R207)
The GIST:
```
    response = client.chat.completions.create(
        model=model,
        messages=[
            {
                "role": "system",
                "content": (
                    "You are a Kusto / Azure Data Explorer assistant. "
                    "You have access to the provided tools. "
                    "For each user request, select the most appropriate tool. "
                    "Always use a tool — do not respond with text. "
                    "You are connected to cluster_uri='https://help.kusto.windows.net' "
                    "and database='Samples'. Use these values when calling tools."
                ),
            },
            {"role": "user", "content": prompt},
        ],
        tools=tools,
        tool_choice="required",
    )
```