### PR TITLE
Add full Kusto response format

### DIFF
--- a/fabric_rti_mcp/services/kusto/kusto_config.py
+++ b/fabric_rti_mcp/services/kusto/kusto_config.py
@@ -137,7 +137,7 @@ class KustoConfig:
                     "Expected 'adx' or 'fabric'. Ignoring override."
                 )
 
-        valid_formats = ("columnar", "json", "csv", "tsv", "header_arrays", "kusto_response")
+        valid_formats = ("columnar", "json", "csv", "tsv", "header_arrays", "kusto_response", "full_kusto_response")
         response_format = "kusto_response"
         response_format_env = os.getenv(KustoEnvVarNames.response_format)
         if response_format_env:

--- a/fabric_rti_mcp/services/kusto/kusto_formatter.py
+++ b/fabric_rti_mcp/services/kusto/kusto_formatter.py
@@ -119,6 +119,27 @@ class KustoFormatter:
         )
 
     @staticmethod
+    def to_full_kusto_response(result_set: KustoResponseDataSet | None) -> KustoResponseFormat:
+        if not result_set or not getattr(result_set, "tables", None):
+            return KustoResponseFormat(format="full_kusto_response", data={"tables": []})
+
+        tables: list[dict[str, Any]] = []
+        for table in result_set.tables:
+            table_kind = getattr(table, "table_kind", None)
+            table_kind_value = getattr(table_kind, "value", table_kind)
+            tables.append(
+                {
+                    "name": table.table_name,
+                    "kind": table_kind_value,
+                    "id": table.table_id,
+                    "columns": table.raw_columns,
+                    "rows": table.raw_rows,
+                }
+            )
+
+        return KustoResponseFormat(format="full_kusto_response", data={"tables": tables})
+
+    @staticmethod
     def to_header_arrays(result_set: KustoResponseDataSet | None) -> KustoResponseFormat:
         if not result_set or not getattr(result_set, "primary_results", None):
             return KustoResponseFormat(format="header_arrays", data=[])
@@ -176,6 +197,8 @@ class KustoFormatter:
             return KustoFormatter._parse_header_arrays(data)
         elif format_type == "kusto_response":
             return KustoFormatter._parse_kusto_response(data)
+        elif format_type == "full_kusto_response":
+            return KustoFormatter._parse_full_kusto_response(data)
         else:
             raise ValueError(f"Unsupported format: {format_type}")
 
@@ -334,3 +357,24 @@ class KustoFormatter:
         column_names = [col["ColumnName"] for col in columns]
 
         return [{column_names[i]: row[i] if i < len(row) else None for i in range(len(column_names))} for row in rows]
+
+    @staticmethod
+    def _parse_full_kusto_response(data: Any) -> list[dict[str, Any]]:
+        """Parse full_kusto_response format by returning the primary result rows."""
+        if not isinstance(data, dict):
+            raise ValueError("Invalid full_kusto_response format")
+
+        tables = data.get("tables", [])
+        if not isinstance(tables, list):
+            raise ValueError("Invalid full_kusto_response format")
+
+        primary_table = next((table for table in tables if table.get("kind") == "PrimaryResult"), None)
+        if primary_table is None:
+            primary_table = tables[0] if tables else {"columns": [], "rows": []}
+
+        return KustoFormatter._parse_kusto_response(
+            {
+                "columns": primary_table.get("columns", []),
+                "rows": primary_table.get("rows", []),
+            }
+        )

--- a/fabric_rti_mcp/services/kusto/kusto_formatter.py
+++ b/fabric_rti_mcp/services/kusto/kusto_formatter.py
@@ -365,7 +365,7 @@ class KustoFormatter:
             raise ValueError("Invalid full_kusto_response format")
 
         tables = data.get("tables", [])
-        if not isinstance(tables, list):
+        if not isinstance(tables, list) or any(not isinstance(table, dict) for table in tables):
             raise ValueError("Invalid full_kusto_response format")
 
         primary_table = next((table for table in tables if table.get("kind") == "PrimaryResult"), None)

--- a/fabric_rti_mcp/services/kusto/kusto_service.py
+++ b/fabric_rti_mcp/services/kusto/kusto_service.py
@@ -380,6 +380,7 @@ _FORMAT_DISPATCH: dict[str, Any] = {
     "tsv": KustoFormatter.to_tsv,
     "header_arrays": KustoFormatter.to_header_arrays,
     "kusto_response": KustoFormatter.to_kusto_response,
+    "full_kusto_response": KustoFormatter.to_full_kusto_response,
 }
 
 

--- a/tests/unit/kusto/test_kusto_formatter.py
+++ b/tests/unit/kusto/test_kusto_formatter.py
@@ -407,6 +407,68 @@ class TestParsingFunctionality:
         assert result.format == "kusto_response"
         assert result.data == {"columns": [], "rows": []}
 
+    def test_KustoFormatter_to_full_kusto_response_with_all_tables(self) -> None:
+        """Test full_kusto_response preserves primary, properties, and status tables."""
+        primary = Mock()
+        primary.table_name = "PrimaryResult"
+        primary.table_kind.value = "PrimaryResult"
+        primary.table_id = "primary-id"
+        primary.raw_columns = [{"ColumnName": "State", "DataType": "String"}]
+        primary.raw_rows = [["TEXAS"]]
+
+        properties = Mock()
+        properties.table_name = "@ExtendedProperties"
+        properties.table_kind.value = "QueryProperties"
+        properties.table_id = "properties-id"
+        properties.raw_columns = [{"ColumnName": "Value", "DataType": "String"}]
+        properties.raw_rows = [['{"resource_usage":{"cpu":{"total cpu":"00:00:01"}}}']]
+
+        status = Mock()
+        status.table_name = "QueryStatus"
+        status.table_kind.value = "QueryCompletionInformation"
+        status.table_id = "status-id"
+        status.raw_columns = [{"ColumnName": "Severity", "DataType": "Int32"}]
+        status.raw_rows = [[4]]
+
+        mock_result_set = Mock(spec=KustoResponseDataSet)
+        mock_result_set.tables = [primary, properties, status]
+
+        result = KustoFormatter.to_full_kusto_response(mock_result_set)
+
+        assert result.format == "full_kusto_response"
+        assert result.data == {
+            "tables": [
+                {
+                    "name": "PrimaryResult",
+                    "kind": "PrimaryResult",
+                    "id": "primary-id",
+                    "columns": primary.raw_columns,
+                    "rows": primary.raw_rows,
+                },
+                {
+                    "name": "@ExtendedProperties",
+                    "kind": "QueryProperties",
+                    "id": "properties-id",
+                    "columns": properties.raw_columns,
+                    "rows": properties.raw_rows,
+                },
+                {
+                    "name": "QueryStatus",
+                    "kind": "QueryCompletionInformation",
+                    "id": "status-id",
+                    "columns": status.raw_columns,
+                    "rows": status.raw_rows,
+                },
+            ]
+        }
+
+    def test_KustoFormatter_to_full_kusto_response_empty(self) -> None:
+        """Test full_kusto_response with no result tables."""
+        result = KustoFormatter.to_full_kusto_response(None)
+
+        assert result.format == "full_kusto_response"
+        assert result.data == {"tables": []}
+
     def test_parse_kusto_response_format(self) -> None:
         """Test parsing kusto_response format back to canonical JSON."""
         data = {
@@ -426,3 +488,32 @@ class TestParsingFunctionality:
         """Test parsing kusto_response with empty columns."""
         result = KustoFormatter.parse({"format": "kusto_response", "data": {"columns": [], "rows": []}})
         assert result == []
+
+    def test_parse_full_kusto_response_format(self) -> None:
+        """Test parsing full_kusto_response returns primary result rows."""
+        data = {
+            "tables": [
+                {
+                    "name": "PrimaryResult",
+                    "kind": "PrimaryResult",
+                    "columns": [
+                        {"ColumnName": "State", "DataType": "String"},
+                        {"ColumnName": "Count", "DataType": "Int64"},
+                    ],
+                    "rows": [["TEXAS", 4701], ["KANSAS", 3166]],
+                },
+                {
+                    "name": "@ExtendedProperties",
+                    "kind": "QueryProperties",
+                    "columns": [{"ColumnName": "Value", "DataType": "String"}],
+                    "rows": [["{}"]],
+                },
+            ]
+        }
+
+        result = KustoFormatter.parse({"format": "full_kusto_response", "data": data})
+
+        assert result == [
+            {"State": "TEXAS", "Count": 4701},
+            {"State": "KANSAS", "Count": 3166},
+        ]

--- a/tests/unit/kusto/test_kusto_service.py
+++ b/tests/unit/kusto/test_kusto_service.py
@@ -11,10 +11,10 @@ from fabric_rti_mcp.services.kusto.kusto_config import KustoConfig
 from fabric_rti_mcp.services.kusto.kusto_service import (
     KustoConnectionManager,
     kusto_command,
-    kusto_show_command,
     kusto_diagnostics,
     kusto_known_services,
     kusto_query,
+    kusto_show_command,
     kusto_show_queryplan,
 )
 
@@ -186,6 +186,13 @@ def test_kusto_known_services_probe_mode_env_overrides_default() -> None:
 
     assert config.known_services_probe_mode == "always"
     assert config.should_probe_known_services(CredentialSource.LOCAL_DEVELOPER) is True
+
+
+@patch.dict("os.environ", {"FABRIC_RTI_KUSTO_RESPONSE_FORMAT": "full_kusto_response"}, clear=True)
+def test_response_format_env_accepts_full_kusto_response() -> None:
+    config = KustoConfig.from_env()
+
+    assert config.response_format == "full_kusto_response"
 
 
 @patch("fabric_rti_mcp.services.kusto.kusto_service.CONFIG")
@@ -626,6 +633,36 @@ def test_execute_kusto_response_format(
     assert "rows" in result["data"]
     assert isinstance(result["data"]["columns"], list)
     assert isinstance(result["data"]["rows"], list)
+
+
+@patch("fabric_rti_mcp.services.kusto.kusto_service.CONFIG")
+@patch("fabric_rti_mcp.services.kusto.kusto_service.get_kusto_connection")
+def test_execute_full_kusto_response_format(
+    mock_get_kusto_connection: Mock,
+    mock_config: MagicMock,
+    sample_cluster_uri: str,
+    mock_kusto_response: KustoResponseDataSet,
+) -> None:
+    """Test that _execute returns all Kusto response tables when configured."""
+    mock_client = MagicMock()
+    mock_client.execute.return_value = mock_kusto_response
+
+    mock_connection = MagicMock()
+    mock_connection.query_client = mock_client
+    mock_connection.default_database = "default_db"
+    mock_get_kusto_connection.return_value = mock_connection
+
+    mock_config.response_format = "full_kusto_response"
+    mock_config.timeout_seconds = None
+
+    result = kusto_query("TestTable | take 10", sample_cluster_uri, database="test_db")
+
+    assert result["format"] == "full_kusto_response"
+    assert "tables" in result["data"]
+    assert result["data"]["tables"][0]["name"] == "Table_0"
+    assert result["data"]["tables"][0]["kind"] == "PrimaryResult"
+    assert result["data"]["tables"][0]["columns"] == [{"ColumnName": "TestColumn", "DataType": "string"}]
+    assert result["data"]["tables"][0]["rows"] == [["TestValue"]]
 
 
 # ── kusto_show_queryplan tests ───────────────────────────────────────────────────


### PR DESCRIPTION
Expose all Kusto response tables via FABRIC_RTI_KUSTO_RESPONSE_FORMAT=full_kusto_response so MCP callers can inspect query properties and status tables.