### PR TITLE
Add agentic workload class CRP

### DIFF
--- a/fabric_rti_mcp/services/kusto/kusto_service.py
+++ b/fabric_rti_mcp/services/kusto/kusto_service.py
@@ -318,12 +318,12 @@ _BLOCKED_CRP_KEYS = frozenset(
     {
         "request_readonly",
         "request_readonly_hardline",
-        "request_workload_class",
+        "request_is_agentic",
     }
 )
 
-_AGENTIC_WORKLOAD_CLASS_OPTION = "request_workload_class"
-_AGENTIC_WORKLOAD_CLASS_VALUE = "agentic"
+_AGENT_MARKER_OPTION = "request_is_agentic"
+_AGENT_MARKER_VALUE = True
 
 _TIMESPAN_RE = re.compile(r"^(\d+):(\d{1,2}):(\d{1,2})$")
 
@@ -374,7 +374,7 @@ def _crp(
                 value = _parse_servertimeout(value)
             crp.set_option(key, value)
 
-    crp.set_option(_AGENTIC_WORKLOAD_CLASS_OPTION, _AGENTIC_WORKLOAD_CLASS_VALUE)
+    crp.set_option(_AGENT_MARKER_OPTION, _AGENT_MARKER_VALUE)
 
     return crp
 

--- a/fabric_rti_mcp/services/kusto/kusto_service.py
+++ b/fabric_rti_mcp/services/kusto/kusto_service.py
@@ -318,8 +318,12 @@ _BLOCKED_CRP_KEYS = frozenset(
     {
         "request_readonly",
         "request_readonly_hardline",
+        "request_workload_class",
     }
 )
+
+_AGENTIC_WORKLOAD_CLASS_OPTION = "request_workload_class"
+_AGENTIC_WORKLOAD_CLASS_VALUE = "agentic"
 
 _TIMESPAN_RE = re.compile(r"^(\d+):(\d{1,2}):(\d{1,2})$")
 
@@ -369,6 +373,8 @@ def _crp(
             if key == ClientRequestProperties.request_timeout_option_name:
                 value = _parse_servertimeout(value)
             crp.set_option(key, value)
+
+    crp.set_option(_AGENTIC_WORKLOAD_CLASS_OPTION, _AGENTIC_WORKLOAD_CLASS_VALUE)
 
     return crp
 

--- a/tests/unit/kusto/test_kusto_service.py
+++ b/tests/unit/kusto/test_kusto_service.py
@@ -231,7 +231,7 @@ def test_execute_basic_query(
     assert crp.application == f"fabric-rti-mcp{{{__version__}}}"
     assert crp.client_request_id.startswith("KFRTI_MCP.kusto_query:")  # type: ignore
     assert crp.has_option("request_readonly")
-    assert crp._options["request_workload_class"] == "agentic"
+    assert crp._options["request_is_agentic"] is True
 
     # Verify result format
     assert result["format"] == "columnar"
@@ -287,7 +287,7 @@ def test_execute_with_custom_client_request_properties(
     assert crp.application == f"fabric-rti-mcp{{{__version__}}}"
     assert crp.client_request_id.startswith("KFRTI_MCP.kusto_query:")  # type: ignore
     assert crp.has_option("request_readonly")
-    assert crp._options["request_workload_class"] == "agentic"
+    assert crp._options["request_is_agentic"] is True
 
     # Verify custom properties are set
     assert crp.has_option("request_timeout")
@@ -338,7 +338,7 @@ def test_execute_without_client_request_properties_preserves_behavior(
     assert crp.application == f"fabric-rti-mcp{{{__version__}}}"
     assert crp.client_request_id.startswith("KFRTI_MCP.kusto_query:")  # type: ignore
     assert crp.has_option("request_readonly")
-    assert crp._options["request_workload_class"] == "agentic"
+    assert crp._options["request_is_agentic"] is True
 
     # Verify result format
     assert isinstance(result, dict)
@@ -391,7 +391,7 @@ def test_destructive_operation_with_custom_client_request_properties(
     # Verify default properties are still set
     assert crp.application == f"fabric-rti-mcp{{{__version__}}}"
     assert crp.client_request_id.startswith("KFRTI_MCP.kusto_command:")  # type: ignore
-    assert crp._options["request_workload_class"] == "agentic"
+    assert crp._options["request_is_agentic"] is True
 
     # For destructive operations, request_readonly should NOT be set
     assert not crp.has_option("request_readonly")
@@ -420,7 +420,7 @@ def test_blocked_crp_keys_raise_error(
     blocked_keys = [
         "request_readonly",
         "request_readonly_hardline",
-        "request_workload_class",
+        "request_is_agentic",
     ]
 
     for key in blocked_keys:
@@ -462,7 +462,7 @@ def test_show_command_crp(
     assert isinstance(crp, ClientRequestProperties)
     assert crp.has_option("request_readonly")
     assert crp.client_request_id.startswith("KFRTI_MCP.kusto_show_command:")  # type: ignore
-    assert crp._options["request_workload_class"] == "agentic"
+    assert crp._options["request_is_agentic"] is True
 
 
 @patch("fabric_rti_mcp.services.kusto.kusto_service.get_kusto_connection")
@@ -667,7 +667,7 @@ def test_show_queryplan_constructs_correct_command(
     crp = args[2]
     assert isinstance(crp, ClientRequestProperties)
     assert crp.client_request_id.startswith("KFRTI_MCP.kusto_show_queryplan:")
-    assert crp._options["request_workload_class"] == "agentic"
+    assert crp._options["request_is_agentic"] is True
 
     assert result["query_text"] == "StormEvents | count"
     assert result["stats"]["PlanSize"] == 9487

--- a/tests/unit/kusto/test_kusto_service.py
+++ b/tests/unit/kusto/test_kusto_service.py
@@ -11,10 +11,10 @@ from fabric_rti_mcp.services.kusto.kusto_config import KustoConfig
 from fabric_rti_mcp.services.kusto.kusto_service import (
     KustoConnectionManager,
     kusto_command,
-    kusto_show_command,
     kusto_diagnostics,
     kusto_known_services,
     kusto_query,
+    kusto_show_command,
     kusto_show_queryplan,
 )
 
@@ -231,6 +231,7 @@ def test_execute_basic_query(
     assert crp.application == f"fabric-rti-mcp{{{__version__}}}"
     assert crp.client_request_id.startswith("KFRTI_MCP.kusto_query:")  # type: ignore
     assert crp.has_option("request_readonly")
+    assert crp._options["request_workload_class"] == "agentic"
 
     # Verify result format
     assert result["format"] == "columnar"
@@ -286,6 +287,7 @@ def test_execute_with_custom_client_request_properties(
     assert crp.application == f"fabric-rti-mcp{{{__version__}}}"
     assert crp.client_request_id.startswith("KFRTI_MCP.kusto_query:")  # type: ignore
     assert crp.has_option("request_readonly")
+    assert crp._options["request_workload_class"] == "agentic"
 
     # Verify custom properties are set
     assert crp.has_option("request_timeout")
@@ -336,6 +338,7 @@ def test_execute_without_client_request_properties_preserves_behavior(
     assert crp.application == f"fabric-rti-mcp{{{__version__}}}"
     assert crp.client_request_id.startswith("KFRTI_MCP.kusto_query:")  # type: ignore
     assert crp.has_option("request_readonly")
+    assert crp._options["request_workload_class"] == "agentic"
 
     # Verify result format
     assert isinstance(result, dict)
@@ -388,6 +391,7 @@ def test_destructive_operation_with_custom_client_request_properties(
     # Verify default properties are still set
     assert crp.application == f"fabric-rti-mcp{{{__version__}}}"
     assert crp.client_request_id.startswith("KFRTI_MCP.kusto_command:")  # type: ignore
+    assert crp._options["request_workload_class"] == "agentic"
 
     # For destructive operations, request_readonly should NOT be set
     assert not crp.has_option("request_readonly")
@@ -416,6 +420,7 @@ def test_blocked_crp_keys_raise_error(
     blocked_keys = [
         "request_readonly",
         "request_readonly_hardline",
+        "request_workload_class",
     ]
 
     for key in blocked_keys:
@@ -457,6 +462,7 @@ def test_show_command_crp(
     assert isinstance(crp, ClientRequestProperties)
     assert crp.has_option("request_readonly")
     assert crp.client_request_id.startswith("KFRTI_MCP.kusto_show_command:")  # type: ignore
+    assert crp._options["request_workload_class"] == "agentic"
 
 
 @patch("fabric_rti_mcp.services.kusto.kusto_service.get_kusto_connection")
@@ -661,6 +667,7 @@ def test_show_queryplan_constructs_correct_command(
     crp = args[2]
     assert isinstance(crp, ClientRequestProperties)
     assert crp.client_request_id.startswith("KFRTI_MCP.kusto_show_queryplan:")
+    assert crp._options["request_workload_class"] == "agentic"
 
     assert result["query_text"] == "StormEvents | count"
     assert result["stats"]["PlanSize"] == 9487


### PR DESCRIPTION
Stamp Kusto requests from the MCP server with request_workload_class=agentic and prevent callers from overriding the workload class option.