### PR TITLE
feat: add configurable tool allow list

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ The skill references the Fabric RTI MCP tools (`kusto_query`, `kusto_command`, `
 
 ### Available tools
 
-#### Eventhouse (Kusto) - 13 Tools:
+#### Eventhouse (Kusto) - 13 Tools + 1 Optional:
 - **`kusto_known_services`** - List all available Kusto services configured in the MCP
 - **`kusto_query`** - Execute KQL queries on the specified database
 - **`kusto_command`** - Execute Kusto management commands (`.show`, `.create`, `.alter`, `.drop`)
@@ -96,7 +96,7 @@ The skill references the Fabric RTI MCP tools (`kusto_query`, `kusto_command`, `
 - **`kusto_graph_query`** - Execute graph queries using snapshots or transient graphs
 - **`kusto_sample_entity`** - Retrieve sample records from a table, external table, materialized view, or function
 - **`kusto_ingest_inline_into_table`** - Ingest inline CSV data into a specified table
-- **`kusto_get_shots`** - Retrieve semantically similar query examples from a shots table using AI embeddings
+- **`kusto_get_shots`** *(when `KUSTO_SHOTS_TABLE` is configured)* - Find similar saved KQL queries
 - **`kusto_deeplink_from_query`** - Generate a deeplink URL to open a KQL query in Azure Data Explorer Web Explorer or Microsoft Fabric query workbench
 - **`kusto_show_queryplan`** - Retrieve the execution plan for a KQL query without running it. Returns planning stats (PlanSize, RelopSize), the logical operator tree, and execution hints (estimated row counts, concurrency/spread hints, per-shard scan info with filter detection). Useful for comparing query approaches, catching expensive joins, and validating query syntax before execution.
 - **`kusto_diagnostics`** - Run a best-effort suite of cluster diagnostic commands and return a unified summary. Sections: capacity (resource slots), cluster (nodes/hardware), principal roles (caller permissions), internal diagnostics (health/utilization), workload groups, rowstores, and ingestion failures (last 24h). Each section runs independently — permission failures on one section don't block others.
@@ -297,10 +297,13 @@ None - the server will work with default settings for demo purposes.
 | `KUSTO_KNOWN_SERVICES` | Kusto | JSON array of preconfigured Kusto services | None | `[{"service_uri":"https://cluster1.kusto.windows.net","default_database":"DB1","description":"Prod"}]` |
 | `KUSTO_EAGER_CONNECT` | Kusto | Whether to eagerly connect to default service on startup (not recommended) | `false` | `true` or `false` |
 | `KUSTO_ALLOW_UNKNOWN_SERVICES` | Kusto | Security setting to allow connections to services not in `KUSTO_KNOWN_SERVICES` | `true` | `true` or `false` |
-| `KUSTO_SHOTS_TABLE` | Kusto | Default shots table name for `kusto_get_shots` when not provided as a parameter | None | `MyDatabase.ShotsTable` |
+| `KUSTO_SHOTS_TABLE` | Kusto | Enable `kusto_get_shots` and set its default shots table | None | `MyDatabase.ShotsTable` |
 | `FABRIC_API_BASE` | Global | Base URL for Microsoft Fabric API | `https://api.fabric.microsoft.com/v1` | `https://api.fabric.microsoft.com/v1` |
 | `FABRIC_BASE_URL` | Global | Base URL for Microsoft Fabric web interface | `https://fabric.microsoft.com` | `https://fabric.microsoft.com` |
+| `FABRIC_RTI_ALLOWED_TOOLS` | Global | Comma-separated service names or full tool names to expose | All tools | `kusto,map_get` |
 | `FABRIC_RTI_KUSTO_DEEPLINK_STYLE` | Kusto | Override auto-detection of deeplink style | None | `adx` or `fabric` |
+
+`FABRIC_RTI_ALLOWED_TOOLS` accepts service names derived from the registered `*_tools` modules and full tool names.
 
 ### Embedding Endpoint Configuration
 

--- a/fabric_rti_mcp/server.py
+++ b/fabric_rti_mcp/server.py
@@ -3,6 +3,7 @@ import signal
 import sys
 import types
 from datetime import datetime, timezone
+from typing import Any
 
 from mcp.server.fastmcp import FastMCP
 from mcp.server.transport_security import TransportSecuritySettings
@@ -15,6 +16,7 @@ from fabric_rti_mcp.compat.ms_foundry import SchemaCompatibleMCP
 from fabric_rti_mcp.config import global_config as config
 from fabric_rti_mcp.config import logger
 from fabric_rti_mcp.config.obo import obo_config
+from fabric_rti_mcp.services import AddTool
 from fabric_rti_mcp.services.activator import activator_tools
 from fabric_rti_mcp.services.eventstream import eventstream_tools
 from fabric_rti_mcp.services.kusto import kusto_config, kusto_tools
@@ -33,15 +35,48 @@ def setup_shutdown_handler(sig: int, frame: types.FrameType | None) -> None:
     sys.exit(0)
 
 
+def add_allowed_tools(service_tool_modules: tuple[Any, ...], allowed_tools: set[str], add_tool: AddTool) -> None:
+    known_services = {
+        service_tools.__name__.rsplit(".", 1)[-1].removesuffix("_tools"): service_tools
+        for service_tools in service_tool_modules
+    }
+    allowed_service_names = (
+        set(known_services)
+        if not allowed_tools
+        else {tool if tool in known_services else tool.split("_", 1)[0] for tool in allowed_tools}
+    )
+    unknown_services = allowed_service_names - set(known_services)
+    if unknown_services:
+        unknown = ", ".join(sorted(unknown_services))
+        raise ValueError(f"Unknown entries in FABRIC_RTI_ALLOWED_TOOLS: {unknown}")
+
+    known_tool_names: set[str] = set()
+
+    def filtered_add_tool(tool: Any, **kwargs: Any) -> None:
+        tool_name = tool.__name__.lower()
+        known_tool_names.add(tool_name)
+        service_name = tool_name.split("_", 1)[0]
+        if not allowed_tools or service_name in allowed_tools or tool_name in allowed_tools:
+            add_tool(tool, **kwargs)
+
+    for service_name, service_tools in known_services.items():
+        if service_name in allowed_service_names:
+            service_tools.register_tools(filtered_add_tool)
+
+    unknown_entries = allowed_tools - set(known_services) - known_tool_names
+    if unknown_entries:
+        unknown = ", ".join(sorted(unknown_entries))
+        raise ValueError(f"Unknown entries in FABRIC_RTI_ALLOWED_TOOLS: {unknown}")
+
+
 def register_tools(mcp: FastMCP) -> None:
     """Register all tools with the MCP server."""
     logger.info("Kusto configuration keys found in environment:")
     logger.info(", ".join(kusto_config.KustoConfig.existing_env_vars()))
 
-    kusto_tools.register_tools(mcp)
-    eventstream_tools.register_tools(mcp)
-    activator_tools.register_tools(mcp)
-    map_tools.register_tools(mcp)
+    service_tool_modules = (kusto_tools, eventstream_tools, activator_tools, map_tools)
+    allowed_tools = {tool.lower() for tool in _split_comma_separated(os.getenv("FABRIC_RTI_ALLOWED_TOOLS", ""))}
+    add_allowed_tools(service_tool_modules, allowed_tools, mcp.add_tool)
 
 
 # Health check function defined at module level

--- a/fabric_rti_mcp/services/__init__.py
+++ b/fabric_rti_mcp/services/__init__.py
@@ -1,0 +1,3 @@
+from collections.abc import Callable
+
+AddTool = Callable[..., None]

--- a/fabric_rti_mcp/services/activator/activator_tools.py
+++ b/fabric_rti_mcp/services/activator/activator_tools.py
@@ -1,20 +1,20 @@
-from mcp.server.fastmcp import FastMCP
 from mcp.types import ToolAnnotations
 
+from fabric_rti_mcp.services import AddTool
 from fabric_rti_mcp.services.activator.activator_service import DEFAULT_ACTIVATOR_SERVICE
 
 
-def register_tools(mcp: FastMCP) -> None:
+def register_tools(add_tool: AddTool) -> None:
     """Register all Activator tools with the MCP server."""
 
     # Read-only tools (queries, list operations)
-    mcp.add_tool(
+    add_tool(
         DEFAULT_ACTIVATOR_SERVICE.activator_list_artifacts,
         annotations=ToolAnnotations(readOnlyHint=True, destructiveHint=False),
     )
 
     # Destructive tools (create, update, delete operations)
-    mcp.add_tool(
+    add_tool(
         DEFAULT_ACTIVATOR_SERVICE.activator_create_trigger,
         annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=True),
     )

--- a/fabric_rti_mcp/services/eventstream/eventstream_builder_tools.py
+++ b/fabric_rti_mcp/services/eventstream/eventstream_builder_tools.py
@@ -1,60 +1,60 @@
-from mcp.server.fastmcp import FastMCP
 from mcp.types import ToolAnnotations
 
+from fabric_rti_mcp.services import AddTool
 from fabric_rti_mcp.services.eventstream import eventstream_builder_service
 
 
-def register_tools(mcp: FastMCP) -> None:
+def register_tools(add_tool: AddTool) -> None:
     # Session management tools (read-only for getting, potentially destructive for clearing)
-    mcp.add_tool(
+    add_tool(
         eventstream_builder_service.eventstream_start_definition,
         annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=False),
     )
-    mcp.add_tool(
+    add_tool(
         eventstream_builder_service.eventstream_get_current_definition,
         annotations=ToolAnnotations(readOnlyHint=True, destructiveHint=False),
     )
-    mcp.add_tool(
+    add_tool(
         eventstream_builder_service.eventstream_clear_definition,
         annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=True),
     )
 
     # Data source tools (modify definition - potentially destructive)
-    mcp.add_tool(
+    add_tool(
         eventstream_builder_service.eventstream_add_sample_data_source,
         annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=False),
     )
-    mcp.add_tool(
+    add_tool(
         eventstream_builder_service.eventstream_add_custom_endpoint_source,
         annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=False),
     )
 
     # Stream tools (modify definition - potentially destructive)
-    mcp.add_tool(
+    add_tool(
         eventstream_builder_service.eventstream_add_derived_stream,
         annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=False),
     )
 
     # Destination tools (modify definition - potentially destructive)
-    mcp.add_tool(
+    add_tool(
         eventstream_builder_service.eventstream_add_eventhouse_destination,
         annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=False),
     )
-    mcp.add_tool(
+    add_tool(
         eventstream_builder_service.eventstream_add_custom_endpoint_destination,
         annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=False),
     )
 
     # Validation and creation tools
-    mcp.add_tool(
+    add_tool(
         eventstream_builder_service.eventstream_validate_definition,
         annotations=ToolAnnotations(readOnlyHint=True, destructiveHint=False),
     )
-    mcp.add_tool(
+    add_tool(
         eventstream_builder_service.eventstream_create_from_definition,
         annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=True),
     )
-    mcp.add_tool(
+    add_tool(
         eventstream_builder_service.eventstream_list_available_components,
         annotations=ToolAnnotations(readOnlyHint=True, destructiveHint=False),
     )

--- a/fabric_rti_mcp/services/eventstream/eventstream_tools.py
+++ b/fabric_rti_mcp/services/eventstream/eventstream_tools.py
@@ -1,39 +1,39 @@
-from mcp.server.fastmcp import FastMCP
 from mcp.types import ToolAnnotations
 
+from fabric_rti_mcp.services import AddTool
 from fabric_rti_mcp.services.eventstream import eventstream_builder_tools, eventstream_service
 
 
-def register_tools(mcp: FastMCP) -> None:
+def register_tools(add_tool: AddTool) -> None:
     """Register all Eventstream tools with the MCP server using ToolAnnotations pattern."""
 
     # Read-only tools (queries, list operations)
-    mcp.add_tool(
+    add_tool(
         eventstream_service.eventstream_list,
         annotations=ToolAnnotations(readOnlyHint=True, destructiveHint=False),
     )
-    mcp.add_tool(
+    add_tool(
         eventstream_service.eventstream_get,
         annotations=ToolAnnotations(readOnlyHint=True, destructiveHint=False),
     )
-    mcp.add_tool(
+    add_tool(
         eventstream_service.eventstream_get_definition,
         annotations=ToolAnnotations(readOnlyHint=True, destructiveHint=False),
     )
 
     # Destructive tools (create, update, delete operations)
-    mcp.add_tool(
+    add_tool(
         eventstream_service.eventstream_create,
         annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=True),
     )
-    mcp.add_tool(
+    add_tool(
         eventstream_service.eventstream_update,
         annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=True),
     )
-    mcp.add_tool(
+    add_tool(
         eventstream_service.eventstream_delete,
         annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=True),
     )
 
     # Register builder tools
-    eventstream_builder_tools.register_tools(mcp)
+    eventstream_builder_tools.register_tools(add_tool)

--- a/fabric_rti_mcp/services/kusto/kusto_service.py
+++ b/fabric_rti_mcp/services/kusto/kusto_service.py
@@ -930,20 +930,10 @@ def kusto_get_shots(
     client_request_properties: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     """
-    Retrieves KQL query examples that semantically resemble the user's prompt.
+    Find similar saved KQL queries.
 
-    IMPORTANT: Call this tool BEFORE writing any KQL query. The returned shots contain
-    expert-written KQL examples that reveal the correct databases, tables, column names,
-    and query patterns for this cluster. Without this context, you are likely to query
-    the wrong table or database.
-
-    Use this to:
-    - Discover which databases and tables contain the data you need
-    - Learn the correct column names and schema for a given domain
-    - Find proven query patterns as starting points
-
-    The returned shots come from a curated collection of expert-written examples
-    paired with natural language descriptions.
+    Semantic search returns existing query examples that are relevant to the user's
+    prompt, so they can be used as starting points for similar requests.
 
     :param prompt: The user prompt to find similar shots for.
     :param shots_table_name: Name of the table containing the shots. The table should have "EmbeddingText" (string)

--- a/fabric_rti_mcp/services/kusto/kusto_tools.py
+++ b/fabric_rti_mcp/services/kusto/kusto_tools.py
@@ -1,63 +1,64 @@
-from mcp.server.fastmcp import FastMCP
 from mcp.types import ToolAnnotations
 
+from fabric_rti_mcp.services import AddTool
 from fabric_rti_mcp.services.kusto import kusto_service
 
 
-def register_tools(mcp: FastMCP) -> None:
-    mcp.add_tool(
+def register_tools(add_tool: AddTool) -> None:
+    add_tool(
         kusto_service.kusto_known_services,
         annotations=ToolAnnotations(readOnlyHint=True, destructiveHint=False),
     )
-    mcp.add_tool(
+    add_tool(
         kusto_service.kusto_query,
         annotations=ToolAnnotations(readOnlyHint=True, destructiveHint=False),
     )
-    mcp.add_tool(
+    add_tool(
         kusto_service.kusto_command,
         annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=True),
     )
-    mcp.add_tool(
+    add_tool(
         kusto_service.kusto_show_command,
         annotations=ToolAnnotations(readOnlyHint=True, destructiveHint=False),
     )
-    mcp.add_tool(
+    add_tool(
         kusto_service.kusto_list_entities,
         annotations=ToolAnnotations(readOnlyHint=True, destructiveHint=False),
     )
-    mcp.add_tool(
+    add_tool(
         kusto_service.kusto_describe_database,
         annotations=ToolAnnotations(readOnlyHint=True, destructiveHint=False),
     )
-    mcp.add_tool(
+    add_tool(
         kusto_service.kusto_describe_database_entity,
         annotations=ToolAnnotations(readOnlyHint=True, destructiveHint=False),
     )
-    mcp.add_tool(
+    add_tool(
         kusto_service.kusto_graph_query,
         annotations=ToolAnnotations(readOnlyHint=True, destructiveHint=False),
     )
-    mcp.add_tool(
+    add_tool(
         kusto_service.kusto_sample_entity,
         annotations=ToolAnnotations(readOnlyHint=True, destructiveHint=False),
     )
-    mcp.add_tool(
+    add_tool(
         kusto_service.kusto_ingest_inline_into_table,
         annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=False),
     )
-    mcp.add_tool(
-        kusto_service.kusto_get_shots,
-        annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=False),
-    )
-    mcp.add_tool(
+    if kusto_service.CONFIG.shots_table:
+        add_tool(
+            kusto_service.kusto_get_shots,
+            annotations=ToolAnnotations(readOnlyHint=True, destructiveHint=False),
+        )
+    add_tool(
         kusto_service.kusto_deeplink_from_query,
         annotations=ToolAnnotations(readOnlyHint=True, destructiveHint=False),
     )
-    mcp.add_tool(
+    add_tool(
         kusto_service.kusto_show_queryplan,
         annotations=ToolAnnotations(readOnlyHint=True, destructiveHint=False),
     )
-    mcp.add_tool(
+    add_tool(
         kusto_service.kusto_diagnostics,
         annotations=ToolAnnotations(readOnlyHint=True, destructiveHint=False),
     )

--- a/fabric_rti_mcp/services/map/map_tools.py
+++ b/fabric_rti_mcp/services/map/map_tools.py
@@ -1,45 +1,45 @@
-from mcp.server.fastmcp import FastMCP
 from mcp.types import ToolAnnotations
 
+from fabric_rti_mcp.services import AddTool
 from fabric_rti_mcp.services.map import map_service
 
 
-def register_tools(mcp: FastMCP) -> None:
+def register_tools(add_tool: AddTool) -> None:
     """Register all Map tools with the MCP server."""
 
     # Read-only tools (queries, list operations)
-    mcp.add_tool(
+    add_tool(
         map_service.map_list,
         annotations=ToolAnnotations(readOnlyHint=True, destructiveHint=False),
     )
 
-    mcp.add_tool(
+    add_tool(
         map_service.map_get,
         annotations=ToolAnnotations(readOnlyHint=True, destructiveHint=False),
     )
 
-    mcp.add_tool(
+    add_tool(
         map_service.map_get_definition,
         annotations=ToolAnnotations(readOnlyHint=True, destructiveHint=False),
     )
 
     # Destructive tools (create, update, delete operations)
-    mcp.add_tool(
+    add_tool(
         map_service.map_create,
         annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=True),
     )
 
-    mcp.add_tool(
+    add_tool(
         map_service.map_update_definition,
         annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=True),
     )
 
-    mcp.add_tool(
+    add_tool(
         map_service.map_update,
         annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=True),
     )
 
-    mcp.add_tool(
+    add_tool(
         map_service.map_delete,
         annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=True),
     )

--- a/tests/live/test_kusto_tools_live.py
+++ b/tests/live/test_kusto_tools_live.py
@@ -33,11 +33,12 @@ EXPECTED_KUSTO_TOOLS = [
     "kusto_graph_query",
     "kusto_sample_entity",
     "kusto_ingest_inline_into_table",
-    "kusto_get_shots",
     "kusto_deeplink_from_query",
     "kusto_show_queryplan",
     "kusto_diagnostics",
 ]
+if os.getenv("KUSTO_SHOTS_TABLE"):
+    EXPECTED_KUSTO_TOOLS.append("kusto_get_shots")
 
 
 @dataclass
@@ -579,13 +580,17 @@ class KustoToolsLiveTester:
         print(f"✅ Diagnostics completed; successful sections: {successful_sections}")
 
     async def test_get_shots(self) -> None:
-        """Test kusto_get_shots when configured, otherwise verify its validation path."""
+        """Test kusto_get_shots when configured."""
         print("\n🎯 Testing kusto_get_shots...")
         if not self.client:
             raise RuntimeError("Client not initialized")
 
-        shots_table = os.getenv("KUSTO_LIVE_SHOTS_TABLE") or os.getenv("KUSTO_SHOTS_TABLE")
+        shots_table = os.getenv("KUSTO_SHOTS_TABLE")
         embedding_endpoint = os.getenv("AZ_OPENAI_EMBEDDING_ENDPOINT")
+
+        if not shots_table:
+            print("⚠️  Skipping kusto_get_shots: KUSTO_SHOTS_TABLE is not configured")
+            return
 
         if shots_table and embedding_endpoint:
             result = await self.client.call_tool(
@@ -611,18 +616,6 @@ class KustoToolsLiveTester:
         if shots_table and not embedding_endpoint:
             print("⚠️  Skipping full kusto_get_shots call: AZ_OPENAI_EMBEDDING_ENDPOINT is not configured")
             return
-
-        result = await self.client.call_tool(
-            "kusto_get_shots",
-            {
-                "prompt": "Find a few storm events in Texas",
-                "cluster_uri": self.test_cluster_uri,
-                "database": self.test_database,
-            },
-        )
-        assert not result.get("success"), "Expected kusto_get_shots to require a shots table when not configured"
-        assert "shots_table_name" in result.get("error", ""), f"Unexpected validation error: {result}"
-        print("✅ kusto_get_shots validation path confirmed")
 
     async def test_describe_database(self) -> None:
         """Test kusto_describe_database tool."""
@@ -822,7 +815,7 @@ class KustoToolsLiveTester:
             await self._run_test("kusto_deeplink_from_query", optional_scope, False, self.test_deeplink_from_query)
             await self._run_test("kusto_show_queryplan", optional_scope, False, self.test_show_queryplan)
             await self._run_test("kusto_diagnostics", optional_scope, False, self.test_diagnostics)
-            await self._run_test("kusto_get_shots validation", optional_scope, False, self.test_get_shots)
+            await self._run_test("kusto_get_shots", optional_scope, False, self.test_get_shots)
             await self._run_test("kusto_describe_database", optional_scope, False, self.test_describe_database)
             await self._run_test(
                 "kusto_describe_database_entity",

--- a/tests/live/test_kusto_tools_live_http.py
+++ b/tests/live/test_kusto_tools_live_http.py
@@ -313,8 +313,9 @@ class KustoHttpClientTester:
                 "kusto_graph_query",
                 "kusto_sample_entity",
                 "kusto_ingest_inline_into_table",
-                "kusto_get_shots",
             ]
+            if os.getenv("KUSTO_SHOTS_TABLE"):
+                expected_kusto_tools.append("kusto_get_shots")
 
             missing_tools = set(expected_kusto_tools) - set(kusto_tools)
             if missing_tools:

--- a/tests/unit/compat/test_schema_simplification.py
+++ b/tests/unit/compat/test_schema_simplification.py
@@ -69,10 +69,10 @@ class TestSchemaCompatibleMCP:
         from fabric_rti_mcp.services.kusto import kusto_tools
         from fabric_rti_mcp.services.map import map_tools
 
-        kusto_tools.register_tools(mcp)
-        eventstream_tools.register_tools(mcp)
-        activator_tools.register_tools(mcp)
-        map_tools.register_tools(mcp)
+        kusto_tools.register_tools(mcp.add_tool)
+        eventstream_tools.register_tools(mcp.add_tool)
+        activator_tools.register_tools(mcp.add_tool)
+        map_tools.register_tools(mcp.add_tool)
 
         tools = asyncio.run(mcp.list_tools())
         assert len(tools) > 0

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -1,8 +1,123 @@
+import asyncio
 from types import SimpleNamespace
+from typing import Any
 
 import pytest
+from mcp.server.fastmcp import FastMCP
 
-from fabric_rti_mcp.server import build_transport_security_settings
+from fabric_rti_mcp.compat.ms_foundry import SchemaCompatibleMCP
+from fabric_rti_mcp.server import add_allowed_tools, build_transport_security_settings, register_tools
+from fabric_rti_mcp.services import AddTool
+from fabric_rti_mcp.services.activator import activator_tools
+from fabric_rti_mcp.services.eventstream import eventstream_tools
+from fabric_rti_mcp.services.kusto import kusto_tools
+from fabric_rti_mcp.services.kusto.kusto_config import KustoConfig
+
+
+def _tool_names(mcp: FastMCP) -> set[str]:
+    return {tool.name for tool in asyncio.run(mcp.list_tools())}
+
+
+def test_add_allowed_tools_skips_services_and_filters_tools() -> None:
+    visited_services: list[str] = []
+    registered_tools: list[str] = []
+
+    def kusto_query() -> None:
+        pass
+
+    def map_get() -> None:
+        pass
+
+    def map_list() -> None:
+        pass
+
+    def eventstream_list() -> None:
+        pass
+
+    def service(name: str, *tools: Any) -> SimpleNamespace:
+        def register_service_tools(add_tool: AddTool) -> None:
+            visited_services.append(name)
+            for tool in tools:
+                add_tool(tool)
+
+        return SimpleNamespace(
+            __name__=f"fabric_rti_mcp.services.{name}.{name}_tools",
+            register_tools=register_service_tools,
+        )
+
+    services = (
+        service("kusto", kusto_query),
+        service("eventstream", eventstream_list),
+        service("map", map_get, map_list),
+    )
+
+    add_allowed_tools(
+        services,
+        {"kusto", "map_get"},
+        lambda tool, **kwargs: registered_tools.append(tool.__name__),
+    )
+
+    assert visited_services == ["kusto", "map"]
+    assert registered_tools == ["kusto_query", "map_get"]
+
+
+@pytest.mark.parametrize("mcp_class", [FastMCP, SchemaCompatibleMCP])
+def test_register_tools_allows_services_and_full_tool_names(
+    monkeypatch: pytest.MonkeyPatch, mcp_class: type[FastMCP]
+) -> None:
+    monkeypatch.setenv("FABRIC_RTI_ALLOWED_TOOLS", "kusto,map_get")
+    monkeypatch.setattr(kusto_tools.kusto_service, "CONFIG", KustoConfig())
+    monkeypatch.setattr(
+        eventstream_tools,
+        "register_tools",
+        lambda add_tool: pytest.fail("Excluded eventstream service should not be visited"),
+    )
+    monkeypatch.setattr(
+        activator_tools,
+        "register_tools",
+        lambda add_tool: pytest.fail("Excluded activator service should not be visited"),
+    )
+    mcp = mcp_class("test")
+
+    register_tools(mcp)
+    tool_names = _tool_names(mcp)
+
+    assert "kusto_query" in tool_names
+    assert "map_get" in tool_names
+    assert "map_list" not in tool_names
+    assert all(name.startswith("kusto_") or name == "map_get" for name in tool_names)
+
+
+def test_register_tools_rejects_unknown_entries(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("FABRIC_RTI_ALLOWED_TOOLS", "maps")
+    mcp = FastMCP("test")
+
+    with pytest.raises(ValueError, match="Unknown entries in FABRIC_RTI_ALLOWED_TOOLS: maps"):
+        register_tools(mcp)
+
+
+def test_get_shots_is_hidden_without_configured_table(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("FABRIC_RTI_ALLOWED_TOOLS", raising=False)
+    monkeypatch.setattr(kusto_tools.kusto_service, "CONFIG", KustoConfig())
+    mcp = FastMCP("test")
+
+    register_tools(mcp)
+
+    assert "kusto_get_shots" not in _tool_names(mcp)
+
+
+def test_get_shots_registration_metadata(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("FABRIC_RTI_ALLOWED_TOOLS", raising=False)
+    monkeypatch.setattr(kusto_tools.kusto_service, "CONFIG", KustoConfig(shots_table="Shots"))
+    mcp = FastMCP("test")
+
+    register_tools(mcp)
+    get_shots = next(tool for tool in asyncio.run(mcp.list_tools()) if tool.name == "kusto_get_shots")
+
+    assert get_shots.description is not None
+    assert get_shots.description.strip().splitlines()[0] == "Find similar saved KQL queries."
+    assert get_shots.annotations is not None
+    assert get_shots.annotations.readOnlyHint is True
 
 
 def test_transport_security_uses_explicit_allowlists(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary
- add `FABRIC_RTI_ALLOWED_TOOLS` support for whole services or individual tools
- filter tools before FastMCP registration through an `AddTool` callback
- expose `kusto_get_shots` only when `KUSTO_SHOTS_TABLE` is configured and clarify its description

## Validation
- Ruff format and check passed
- `ty check fabric_rti_mcp` passed
- all 235 unit tests passed
- stdio live suite passed all checks
- HTTP tool discovery and authentication checks passed; the live harness logged its existing Python 3.10 fractional-second parsing issue after a successful query
- filtered live configuration exposed exactly `kusto_query` and `map_get`, and rejected a direct call to excluded `kusto_query`