### PR TITLE
Add SLM embedding support to kusto_get_shots

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,10 +5,22 @@
     "version": "0.2.0",
     "configurations": [
         {
-            "name": "Python Debugger: Attach to Process Id",
+            "name": "Python Debugger: Attach by Process ID",
             "type": "debugpy",
             "request": "attach",
             "processId": "${command:pickProcess}",
+            "justMyCode": true
+        },
+        {
+            "name": "Python Debugger: Attach to Fabric RTI MCP",
+            "type": "debugpy",
+            "request": "attach",
+            "connect": {
+                "host": "127.0.0.1",
+                "port": 5678
+            },
+            "preLaunchTask": "Inject debugger into Fabric RTI MCP",
+            "justMyCode": true
         },
         {
             "name": "Python Debugger: Debug server.py with Arguments",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,20 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "Inject debugger into Fabric RTI MCP",
+            "type": "shell",
+            "command": "$listener = Get-NetTCPConnection -LocalPort 5678 -State Listen -ErrorAction SilentlyContinue; if ($listener) { exit 0 }; $servers = @(Get-CimInstance Win32_Process | Where-Object { $_.Name -eq 'python.exe' -and $_.CommandLine -match '-m\\s+fabric_rti_mcp\\.server' }); if (-not $servers) { throw 'No running fabric_rti_mcp.server Python process was found.' }; $target = $servers | Where-Object { $_.ProcessId -notin $servers.ParentProcessId } | Sort-Object CreationDate -Descending | Select-Object -First 1; if (-not $target) { throw 'Could not identify the Fabric RTI MCP child Python process.' }; $uv = (Get-Command uv -ErrorAction Stop).Source; Start-Process -FilePath $uv -ArgumentList @('--directory', '${workspaceFolder}', 'run', '--with', 'debugpy', 'python', '-m', 'debugpy', '--listen', '127.0.0.1:5678', '--pid', $target.ProcessId) -WindowStyle Hidden; for ($attempt = 0; $attempt -lt 50; $attempt++) { Start-Sleep -Milliseconds 200; if (Get-NetTCPConnection -LocalPort 5678 -State Listen -ErrorAction SilentlyContinue) { exit 0 } }; throw \"debugpy did not start listening for PID $($target.ProcessId).\"",
+            "options": {
+                "shell": {
+                    "executable": "pwsh.exe",
+                    "args": [
+                        "-NoProfile",
+                        "-Command"
+                    ]
+                }
+            },
+            "problemMatcher": []
+        }
+    ]
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,10 @@
 ## Unreleased
 ### Features
 - Added `kusto_deeplink_from_query` tool to generate deeplink URLs for opening KQL queries in the appropriate web explorer UI (Azure Data Explorer Web Explorer or Microsoft Fabric query workbench). Auto-detects cluster type from URI with `.show version` fallback.
+- Added local SLM embedding support to `kusto_get_shots` through a pre-deployed `slm_embeddings_fl` function. Azure OpenAI remains the default for backward compatibility; select `embedding_method="slm"` or configure `KUSTO_SHOTS_EMBEDDING_METHOD=slm`. The SLM model defaults to `harrier-v1-270m` and can be configured with `KUSTO_SHOTS_SLM_MODEL`.
 
 ### Other Changes
+- Optimize `kusto_get_shots` similarity ranking by using the known unit magnitudes of supported embedding vectors.
 - Use docstring as tool description
 - Add annotations (readonly, destructive)
 - Add Attach to proc id + tracing pid on start so we can debug locally
@@ -65,4 +67,3 @@
 ### Other Changes
 - Refactor kusto connection cache and known service URIs
 - Add authority ID support for Kusto
-

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ The skill references the Fabric RTI MCP tools (`kusto_query`, `kusto_command`, `
 - **`kusto_graph_query`** - Execute graph queries using snapshots or transient graphs
 - **`kusto_sample_entity`** - Retrieve sample records from a table, external table, materialized view, or function
 - **`kusto_ingest_inline_into_table`** - Ingest inline CSV data into a specified table
-- **`kusto_get_shots`** - Retrieve semantically similar query examples from a shots table using AI embeddings
+- **`kusto_get_shots`** - Retrieve semantically similar query examples using local SLM or Azure OpenAI embeddings
 - **`kusto_deeplink_from_query`** - Generate a deeplink URL to open a KQL query in Azure Data Explorer Web Explorer or Microsoft Fabric query workbench
 - **`kusto_show_queryplan`** - Retrieve the execution plan for a KQL query without running it. Returns planning stats (PlanSize, RelopSize), the logical operator tree, and execution hints (estimated row counts, concurrency/spread hints, per-shard scan info with filter detection). Useful for comparing query approaches, catching expensive joins, and validating query syntax before execution.
 - **`kusto_diagnostics`** - Run a best-effort suite of cluster diagnostic commands and return a unified summary. Sections: capacity (resource slots), cluster (nodes/hardware), principal roles (caller permissions), internal diagnostics (health/utilization), workload groups, rowstores, and ingestion failures (last 24h). Each section runs independently — permission failures on one section don't block others.
@@ -181,7 +181,7 @@ The process should end with the below settings in your `settings.json` or your `
 }
 ```
 
-> **Note**: All environment variables are optional. The `KUSTO_SERVICE_URI` and `KUSTO_SERVICE_DEFAULT_DB` provide default cluster and database settings. The `AZ_OPENAI_EMBEDDING_ENDPOINT` is only needed for semantic search functionality in the `kusto_get_shots` tool.
+> **Note**: All environment variables are optional. The `KUSTO_SERVICE_URI` and `KUSTO_SERVICE_DEFAULT_DB` provide default cluster and database settings. `AZ_OPENAI_EMBEDDING_ENDPOINT` configures the default AOAI embedding method used by `kusto_get_shots`.
 
 #### From GitHub Copilot CLI
 
@@ -261,13 +261,54 @@ pip install -e ".[dev]"
 Follow the [Manual Install](#🔧-manual-install-install-from-source) instructions.
 
 ### Attach the debugger
-Use the `Python: Attach` configuration in your `launch.json` to attach to the running server. 
-Once VS Code picks up the server and starts it, navigate to its output: 
-1. Open command palette (Ctrl+Shift+P) and run the command `MCP: List Servers`
-2. Navigate to `fabric-rti-mcp` and select `Show Output`
-3. Pick up the process ID (PID) of the server from the output
-4. Run the `Python: Attach` configuration in your `launch.json` file, and paste the PID of the server in the prompt
-5. The debugger will attach to the server process, and you can start debugging
+
+Start the MCP server normally from the client that will invoke its tools, then set a breakpoint on an executable
+line. If you changed the Python source after the server started, restart the MCP server before attaching.
+
+#### Option 1: Attach by process ID
+
+Press F5 and select `Python Debugger: Attach by Process ID`. VS Code needs the PID of the Python process that is
+running `-m fabric_rti_mcp.server`. You can identify it in either of these ways:
+
+1. **VS Code process picker:** Select the matching Python process from the list. If several related processes are
+   shown, select the deepest Python child running `-m fabric_rti_mcp.server`, not the `uv` wrapper.
+2. **Manual PID lookup:** If VS Code asks you to enter a PID instead of displaying the process list, find it with
+   Task Manager or PowerShell:
+   - In Task Manager, open **Details**, enable the **PID** and **Command line** columns, and locate the matching
+     `python.exe` process.
+   - In PowerShell, run:
+
+     ```powershell
+     $servers = @(Get-CimInstance Win32_Process | Where-Object {
+         $_.Name -eq "python.exe" -and
+         $_.CommandLine -match "-m\s+fabric_rti_mcp\.server"
+     })
+
+     $servers |
+         Where-Object { $_.ProcessId -notin $servers.ParentProcessId } |
+         Sort-Object CreationDate -Descending |
+         Select-Object -First 1 ProcessId, CommandLine
+     ```
+
+   Enter the returned `ProcessId` in the VS Code prompt.
+
+On newer Windows versions, `wmic.exe` is disabled or removed. Some Python debugger versions still use it to
+populate the process picker, causing process enumeration to fail. The manual methods above do not require WMIC.
+
+#### Option 2: Inject debugpy and attach on port 5678
+
+This repository includes the `Python Debugger: Attach to Fabric RTI MCP` launch configuration and its
+`Inject debugger into Fabric RTI MCP` pre-launch task. This Windows-specific option uses PowerShell to find the
+deepest Fabric RTI MCP Python process, inject `debugpy`, and connect VS Code to `127.0.0.1:5678`.
+
+1. Ensure the MCP server is already running.
+2. Press F5 and select `Python Debugger: Attach to Fabric RTI MCP`.
+3. Wait for the VS Code debug toolbar to appear.
+4. Invoke the target tool from the same MCP client session that started the attached server.
+
+Do not add `debugpy --listen` to the MCP server command. Some clients may start or reconnect to the command more
+than once, which can cause port collisions. If multiple MCP client sessions are running, close the unrelated
+sessions first so the debugger attaches to the intended server process.
 
 
 ## 🧪 Test the MCP Server
@@ -293,18 +334,76 @@ None - the server will work with default settings for demo purposes.
 |----------|---------|-------------|---------|---------|
 | `KUSTO_SERVICE_URI` | Kusto | Default Kusto cluster URI | None | `https://mycluster.westus.kusto.windows.net` |
 | `KUSTO_SERVICE_DEFAULT_DB` | Kusto | Default database name for Kusto queries | `NetDefaultDB` | `MyDatabase` |
-| `AZ_OPENAI_EMBEDDING_ENDPOINT` | Kusto | Azure OpenAI embedding endpoint for semantic search in `kusto_get_shots` | None | `https://your-resource.openai.azure.com/openai/deployments/text-embedding-ada-002/embeddings?api-version=2024-10-21;impersonate` |
+| `AZ_OPENAI_EMBEDDING_ENDPOINT` | Kusto | Azure OpenAI endpoint used when `kusto_get_shots` selects `embedding_method="aoai"` | None | `https://your-resource.openai.azure.com/openai/deployments/text-embedding-ada-002/embeddings?api-version=2024-10-21;impersonate` |
 | `KUSTO_KNOWN_SERVICES` | Kusto | JSON array of preconfigured Kusto services | None | `[{"service_uri":"https://cluster1.kusto.windows.net","default_database":"DB1","description":"Prod"}]` |
 | `KUSTO_EAGER_CONNECT` | Kusto | Whether to eagerly connect to default service on startup (not recommended) | `false` | `true` or `false` |
 | `KUSTO_ALLOW_UNKNOWN_SERVICES` | Kusto | Security setting to allow connections to services not in `KUSTO_KNOWN_SERVICES` | `true` | `true` or `false` |
 | `KUSTO_SHOTS_TABLE` | Kusto | Default shots table name for `kusto_get_shots` when not provided as a parameter | None | `MyDatabase.ShotsTable` |
+| `KUSTO_SHOTS_EMBEDDING_METHOD` | Kusto | Default embedding method for `kusto_get_shots` | `aoai` | `slm` or `aoai` |
+| `KUSTO_SHOTS_SLM_MODEL` | Kusto | Default SLM model for `kusto_get_shots` | `harrier-v1-270m` | `harrier-v1-270m` |
 | `FABRIC_API_BASE` | Global | Base URL for Microsoft Fabric API | `https://api.fabric.microsoft.com/v1` | `https://api.fabric.microsoft.com/v1` |
 | `FABRIC_BASE_URL` | Global | Base URL for Microsoft Fabric web interface | `https://fabric.microsoft.com` | `https://fabric.microsoft.com` |
 | `FABRIC_RTI_KUSTO_DEEPLINK_STYLE` | Kusto | Override auto-detection of deeplink style | None | `adx` or `fabric` |
 
-### Embedding Endpoint Configuration
+### Shots Embedding Configuration
 
-The `AZ_OPENAI_EMBEDDING_ENDPOINT` is used by the semantic search functionality (e.g., `kusto_get_shots` function) to find similar query examples. 
+All supported AOAI and SLM embedding paths return L2-normalized vectors. `kusto_get_shots` uses their known unit
+magnitudes when calculating cosine similarity to avoid recalculating vector magnitudes for every shot. Custom or
+manually generated `EmbeddingVector` values must therefore also be L2-normalized.
+
+#### SLM embeddings
+
+`kusto_get_shots` defaults to Azure OpenAI embeddings for backward compatibility. To use local SLM embeddings,
+set `embedding_method` to `slm` for an individual call, or set `KUSTO_SHOTS_EMBEDDING_METHOD=slm` for the MCP
+server. Configure the server's default model with `KUSTO_SHOTS_SLM_MODEL`; it defaults to
+`harrier-v1-270m`. Explicit tool arguments override these server defaults. The queried database must contain a
+pre-deployed `slm_embeddings_fl` function. Follow the [SLM embeddings function documentation](https://learn.microsoft.com/en-us/kusto/functions-library/slm-embeddings-fl)
+and select either **Azure Data Explorer** or **Microsoft Fabric** from the **Version** selector in the left pane
+for the correct deployment instructions.
+
+The documented `slm_embeddings_fl` implementation supports:
+
+| Model | Vector dimensions |
+|---|---:|
+| `jina-v2-small` | 512 |
+| `e5-small-v2` | 384 |
+| `harrier-v1-270m` (default) | 640 |
+
+Example SLM arguments:
+
+```json
+{
+  "prompt": "Find a few storm events in Texas",
+  "cluster_uri": "https://mycluster.westus.kusto.windows.net",
+  "database": "MyDatabase",
+  "shots_table_name": "Shots",
+  "embedding_method": "slm",
+  "slm_model_name": "harrier-v1-270m"
+}
+```
+
+The SLM prompt is embedded with the `query:` prefix. The table's `EmbeddingVector` values must use the same model and vector dimension; for retrieval models, embed the stored `EmbeddingText` corpus with the corresponding `passage:` convention.
+
+The MCP tool does not deploy the function or migrate existing shot vectors.
+
+#### Azure OpenAI embeddings
+
+AOAI is the default embedding method. Follow the [AI embeddings plugin documentation](https://learn.microsoft.com/en-us/kusto/query/ai-embeddings-plugin) and select either **Azure Data Explorer** or **Microsoft Fabric** from the **Version** selector in the left pane for the applicable setup instructions.
+
+Example AOAI arguments:
+
+```json
+{
+  "prompt": "Find a few storm events in Texas",
+  "cluster_uri": "https://mycluster.westus.kusto.windows.net",
+  "database": "MyDatabase",
+  "shots_table_name": "Shots",
+  "embedding_method": "aoai",
+  "embedding_endpoint": "https://your-resource.openai.azure.com/openai/deployments/text-embedding-ada-002/embeddings?api-version=2024-10-21;impersonate"
+}
+```
+
+If `embedding_endpoint` isn't supplied, AOAI calls use `AZ_OPENAI_EMBEDDING_ENDPOINT`.
 
 **Format Requirements:**
 ```
@@ -325,7 +424,9 @@ https://{your-openai-resource}.openai.azure.com/openai/deployments/{deployment-n
 ### Configuration of Shots Table
 The `kusto_get_shots` tool retrieves shots that are most similar to your prompt from the shots table. This function requires configuration of:
 - **Shots table**: Should have an "EmbeddingText" (string) column containing the natural language prompt, "AugmentedText" (string) column containing the respective KQL, and "EmbeddingVector" (dynamic) column containing the embedding vector of the EmbeddingText.
-- **Azure OpenAI embedding endpoint**: Used to create embedding vectors for your prompt. Note that this endpoint must use the same model that was used for creating the "EmbeddingVector" column in the shots table.
+- **Matching embeddings**: The prompt and `EmbeddingVector` column must use the same provider, model, vector dimension, and compatible query/corpus conventions.
+
+Existing AOAI calls remain backward compatible. When `embedding_method="slm"` is selected, `embedding_endpoint` is ignored.
 
 ## 🔑 Authentication
 

--- a/fabric_rti_mcp/services/kusto/kusto_config.py
+++ b/fabric_rti_mcp/services/kusto/kusto_config.py
@@ -32,6 +32,8 @@ class KustoEnvVarNames:
     default_service_default_db = "KUSTO_SERVICE_DEFAULT_DB"
     open_ai_embedding_endpoint = "AZ_OPENAI_EMBEDDING_ENDPOINT"
     shots_table = "KUSTO_SHOTS_TABLE"
+    shots_embedding_method = "KUSTO_SHOTS_EMBEDDING_METHOD"
+    shots_slm_model = "KUSTO_SHOTS_SLM_MODEL"
     known_services = "KUSTO_KNOWN_SERVICES"
     eager_connect = "KUSTO_EAGER_CONNECT"
     allow_unknown_services = "KUSTO_ALLOW_UNKNOWN_SERVICES"
@@ -48,6 +50,8 @@ class KustoEnvVarNames:
             KustoEnvVarNames.default_service_default_db,
             KustoEnvVarNames.open_ai_embedding_endpoint,
             KustoEnvVarNames.shots_table,
+            KustoEnvVarNames.shots_embedding_method,
+            KustoEnvVarNames.shots_slm_model,
             KustoEnvVarNames.known_services,
             KustoEnvVarNames.eager_connect,
             KustoEnvVarNames.allow_unknown_services,
@@ -66,10 +70,14 @@ def _env_bool(name: str) -> bool:
 class KustoConfig:
     # Default service. Will be used if no specific service is provided.
     default_service: KustoServiceConfig | None = None
-    # Optional OpenAI embedding endpoint to be used for embeddings where applicable.
+    # Optional OpenAI embedding endpoint used for AOAI embeddings.
     open_ai_embedding_endpoint: str | None = None
     # Default shots table name for the kusto_get_shots tool.
     shots_table: str | None = None
+    # Default embedding method for kusto_get_shots.
+    shots_embedding_method: str = "aoai"
+    # Default SLM model for kusto_get_shots.
+    shots_slm_model: str = "harrier-v1-270m"
     # List of known Kusto services. If empty, no services are configured.
     known_services: list[KustoServiceConfig] | None = None
     # Whether to eagerly connect to the default service on startup.
@@ -103,6 +111,8 @@ class KustoConfig:
 
         open_ai_embedding_endpoint = os.getenv(KustoEnvVarNames.open_ai_embedding_endpoint, None)
         shots_table = os.getenv(KustoEnvVarNames.shots_table, None)
+        shots_embedding_method = os.getenv(KustoEnvVarNames.shots_embedding_method, "aoai")
+        shots_slm_model = os.getenv(KustoEnvVarNames.shots_slm_model, "harrier-v1-270m")
         known_services_string = os.getenv(KustoEnvVarNames.known_services, None)
         known_services: list[KustoServiceConfig] | None = None
         eager_connect = _env_bool(KustoEnvVarNames.eager_connect)
@@ -164,16 +174,18 @@ class KustoConfig:
                 )
 
         return KustoConfig(
-            default_service,
-            open_ai_embedding_endpoint,
-            shots_table,
-            known_services,
-            eager_connect,
-            allow_unknown_services,
-            timeout_seconds,
-            deeplink_style,
-            response_format,
-            known_services_probe_mode,
+            default_service=default_service,
+            open_ai_embedding_endpoint=open_ai_embedding_endpoint,
+            shots_table=shots_table,
+            shots_embedding_method=shots_embedding_method,
+            shots_slm_model=shots_slm_model,
+            known_services=known_services,
+            eager_connect=eager_connect,
+            allow_unknown_services=allow_unknown_services,
+            timeout_seconds=timeout_seconds,
+            deeplink_style=deeplink_style,
+            response_format=response_format,
+            known_services_probe_mode=known_services_probe_mode,
         )
 
     def should_probe_known_services(self, credential_source: CredentialSource) -> bool:

--- a/fabric_rti_mcp/services/kusto/kusto_config.py
+++ b/fabric_rti_mcp/services/kusto/kusto_config.py
@@ -3,11 +3,20 @@ from __future__ import annotations
 import json
 import os
 from dataclasses import dataclass
+from typing import Literal, TypeAlias, get_args
 
 from azure.kusto.data import KustoConnectionStringBuilder
 
 from fabric_rti_mcp.auth.auth_context import CredentialSource
 from fabric_rti_mcp.config import logger
+
+ShotsEmbeddingMethod: TypeAlias = Literal["slm", "aoai"]
+ShotsSlmModel: TypeAlias = Literal["jina-v2-small", "e5-small-v2", "harrier-v1-270m"]
+
+DEFAULT_SHOTS_EMBEDDING_METHOD: ShotsEmbeddingMethod = "aoai"
+DEFAULT_SHOTS_SLM_MODEL: ShotsSlmModel = "harrier-v1-270m"
+SUPPORTED_SHOTS_EMBEDDING_METHODS: tuple[ShotsEmbeddingMethod, ...] = get_args(ShotsEmbeddingMethod)
+SUPPORTED_SHOTS_SLM_MODELS: tuple[ShotsSlmModel, ...] = get_args(ShotsSlmModel)
 
 
 @dataclass(slots=True, frozen=True)
@@ -75,9 +84,9 @@ class KustoConfig:
     # Default shots table name for the kusto_get_shots tool.
     shots_table: str | None = None
     # Default embedding method for kusto_get_shots.
-    shots_embedding_method: str = "aoai"
+    shots_embedding_method: str = DEFAULT_SHOTS_EMBEDDING_METHOD
     # Default SLM model for kusto_get_shots.
-    shots_slm_model: str = "harrier-v1-270m"
+    shots_slm_model: str = DEFAULT_SHOTS_SLM_MODEL
     # List of known Kusto services. If empty, no services are configured.
     known_services: list[KustoServiceConfig] | None = None
     # Whether to eagerly connect to the default service on startup.
@@ -111,8 +120,8 @@ class KustoConfig:
 
         open_ai_embedding_endpoint = os.getenv(KustoEnvVarNames.open_ai_embedding_endpoint, None)
         shots_table = os.getenv(KustoEnvVarNames.shots_table, None)
-        shots_embedding_method = os.getenv(KustoEnvVarNames.shots_embedding_method, "aoai")
-        shots_slm_model = os.getenv(KustoEnvVarNames.shots_slm_model, "harrier-v1-270m")
+        shots_embedding_method = os.getenv(KustoEnvVarNames.shots_embedding_method, DEFAULT_SHOTS_EMBEDDING_METHOD)
+        shots_slm_model = os.getenv(KustoEnvVarNames.shots_slm_model, DEFAULT_SHOTS_SLM_MODEL)
         known_services_string = os.getenv(KustoEnvVarNames.known_services, None)
         known_services: list[KustoServiceConfig] | None = None
         eager_connect = _env_bool(KustoEnvVarNames.eager_connect)

--- a/fabric_rti_mcp/services/kusto/kusto_config.py
+++ b/fabric_rti_mcp/services/kusto/kusto_config.py
@@ -75,6 +75,18 @@ def _env_bool(name: str) -> bool:
     return os.getenv(name, "false").lower() in ("true", "1")
 
 
+def _env_choice(name: str, default: str, supported_values: tuple[str, ...]) -> str:
+    raw_value = os.getenv(name)
+    if raw_value is None:
+        return default
+
+    normalized_value = raw_value.strip().lower()
+    if normalized_value not in supported_values:
+        expected_values = ", ".join(supported_values)
+        raise ValueError(f"Invalid {name}='{raw_value}'. Expected one of: {expected_values}.")
+    return normalized_value
+
+
 @dataclass(slots=True, frozen=True)
 class KustoConfig:
     # Default service. Will be used if no specific service is provided.
@@ -120,8 +132,16 @@ class KustoConfig:
 
         open_ai_embedding_endpoint = os.getenv(KustoEnvVarNames.open_ai_embedding_endpoint, None)
         shots_table = os.getenv(KustoEnvVarNames.shots_table, None)
-        shots_embedding_method = os.getenv(KustoEnvVarNames.shots_embedding_method, DEFAULT_SHOTS_EMBEDDING_METHOD)
-        shots_slm_model = os.getenv(KustoEnvVarNames.shots_slm_model, DEFAULT_SHOTS_SLM_MODEL)
+        shots_embedding_method = _env_choice(
+            KustoEnvVarNames.shots_embedding_method,
+            DEFAULT_SHOTS_EMBEDDING_METHOD,
+            SUPPORTED_SHOTS_EMBEDDING_METHODS,
+        )
+        shots_slm_model = _env_choice(
+            KustoEnvVarNames.shots_slm_model,
+            DEFAULT_SHOTS_SLM_MODEL,
+            SUPPORTED_SHOTS_SLM_MODELS,
+        )
         known_services_string = os.getenv(KustoEnvVarNames.known_services, None)
         known_services: list[KustoServiceConfig] | None = None
         eager_connect = _env_bool(KustoEnvVarNames.eager_connect)

--- a/fabric_rti_mcp/services/kusto/kusto_service.py
+++ b/fabric_rti_mcp/services/kusto/kusto_service.py
@@ -10,7 +10,7 @@ import uuid
 from collections.abc import Callable
 from dataclasses import asdict
 from datetime import timedelta
-from typing import Any, TypeVar
+from typing import Any, Literal, TypeVar
 from urllib.parse import quote, urlparse
 
 from azure.kusto.data import ClientRequestProperties, KustoConnectionStringBuilder
@@ -922,6 +922,8 @@ def kusto_get_shots(
     database: str | None = None,
     embedding_endpoint: str | None = None,
     client_request_properties: dict[str, Any] | None = None,
+    embedding_method: Literal["slm", "aoai"] | None = None,
+    slm_model_name: str | None = None,
 ) -> dict[str, Any]:
     """
     Retrieves KQL query examples that semantically resemble the user's prompt.
@@ -942,16 +944,20 @@ def kusto_get_shots(
     :param prompt: The user prompt to find similar shots for.
     :param shots_table_name: Name of the table containing the shots. The table should have "EmbeddingText" (string)
                              column containing the natural language prompt, "AugmentedText" (string) column containing
-                             the respective KQL, and "EmbeddingVector" (dynamic) column containing the embedding vector
-                             for the NL.
+                             the respective KQL, and "EmbeddingVector" (dynamic) column containing an L2-normalized
+                             embedding vector for the NL.
                              If not provided, uses the KUSTO_SHOTS_TABLE environment variable.
     :param cluster_uri: The URI of the Kusto cluster.
     :param sample_size: Number of most similar shots to retrieve. Defaults to 3.
-    :param database: Optional database name. If not provided, uses the "AI" database or the default database.
-    :param embedding_endpoint: Optional endpoint for the embedding model to use. If not provided, uses the
-                             AZ_OPENAI_EMBEDDING_ENDPOINT environment variable. If no valid endpoint is set,
-                             this function should not be called.
+    :param database: Optional database name. If not provided, uses the default database.
+    :param embedding_endpoint: Azure OpenAI embedding endpoint. Used only when embedding_method is "aoai".
+                             If not provided for AOAI, uses the AZ_OPENAI_EMBEDDING_ENDPOINT environment variable.
     :param client_request_properties: Optional dictionary of additional client request properties.
+    :param embedding_method: Embedding method for the prompt. "slm" invokes a pre-deployed slm_embeddings_fl
+                             function in the queried database. "aoai" uses ai_embeddings and requires an embedding
+                             endpoint. If not provided, uses KUSTO_SHOTS_EMBEDDING_METHOD, which defaults to "aoai".
+    :param slm_model_name: SLM model passed to slm_embeddings_fl. The shots table vectors must use the same model.
+                           If not provided, uses KUSTO_SHOTS_SLM_MODEL, which defaults to "harrier-v1-270m".
     :return: List of dictionaries containing the shots records.
     """
     resolved_table = shots_table_name or CONFIG.shots_table
@@ -960,19 +966,56 @@ def kusto_get_shots(
             "shots_table_name must be provided either as a parameter or via the KUSTO_SHOTS_TABLE environment variable."
         )
 
-    # Use provided endpoint, or fall back to environment variable, or use default
-    endpoint = embedding_endpoint or CONFIG.open_ai_embedding_endpoint
+    resolved_embedding_method = embedding_method if embedding_method is not None else CONFIG.shots_embedding_method
+    normalized_embedding_method = resolved_embedding_method.strip().lower()
+    if normalized_embedding_method not in ("slm", "aoai"):
+        raise ValueError("embedding_method must be either 'slm' or 'aoai'.")
+
+    escaped_prompt = kql_escape_string(prompt)
+    if normalized_embedding_method == "slm":
+        resolved_model_name = slm_model_name if slm_model_name is not None else CONFIG.shots_slm_model
+        normalized_model_name = resolved_model_name.strip()
+        if not normalized_model_name:
+            raise ValueError("slm_model_name must not be empty.")
+
+        embedding_query = f"""
+        let embedded_term = toscalar(
+            print EmbeddingText = '{escaped_prompt}'
+            | extend EmbeddingVector = dynamic(null)
+            | invoke slm_embeddings_fl(
+                text_col='EmbeddingText',
+                embeddings_col='EmbeddingVector',
+                model_name='{kql_escape_string(normalized_model_name)}',
+                prefix='query:')
+            | project EmbeddingVector
+        );"""
+    else:
+        endpoint = embedding_endpoint or CONFIG.open_ai_embedding_endpoint
+        if not endpoint:
+            raise ValueError(
+                "embedding_endpoint must be provided for embedding_method='aoai' either as a parameter "
+                "or via the AZ_OPENAI_EMBEDDING_ENDPOINT environment variable."
+            )
+
+        embedding_query = f"""
+        let model_endpoint = '{kql_escape_string(endpoint)}';
+        let embedded_term = toscalar(evaluate ai_embeddings('{escaped_prompt}', model_endpoint));"""
 
     kql_query = f"""
-        let model_endpoint = '{kql_escape_string(endpoint or "")}';
-        let embedded_term = toscalar(evaluate ai_embeddings('{kql_escape_string(prompt)}', model_endpoint));
+        {embedding_query}
         {kql_escape_entity_name(resolved_table)}
-        | extend similarity = series_cosine_similarity(embedded_term, EmbeddingVector)
+        | extend similarity = series_cosine_similarity(embedded_term, EmbeddingVector, 1.0, 1.0)
         | top {sample_size} by similarity
         | project similarity, EmbeddingText, AugmentedText
     """
 
-    return _execute(kql_query, cluster_uri, database=database, client_request_properties=client_request_properties)
+    return _execute(
+        kql_query,
+        cluster_uri,
+        readonly_override=normalized_embedding_method == "slm",
+        database=database,
+        client_request_properties=client_request_properties,
+    )
 
 
 def _rows_to_dicts(result: dict[str, Any]) -> list[dict[str, Any]]:

--- a/fabric_rti_mcp/services/kusto/kusto_service.py
+++ b/fabric_rti_mcp/services/kusto/kusto_service.py
@@ -1023,6 +1023,8 @@ def kusto_get_shots(
         | project similarity, EmbeddingText, AugmentedText
     """
 
+    # The SLM function loads model artifacts in the Python sandbox, and Kusto's
+    # hard read-only request properties block those external artifact callouts.
     return _execute(
         kql_query,
         cluster_uri,

--- a/fabric_rti_mcp/services/kusto/kusto_service.py
+++ b/fabric_rti_mcp/services/kusto/kusto_service.py
@@ -987,7 +987,7 @@ def kusto_get_shots(
     escaped_prompt = kql_escape_string(prompt)
     if normalized_embedding_method == "slm":
         resolved_model_name = slm_model_name if slm_model_name is not None else CONFIG.shots_slm_model
-        normalized_model_name = resolved_model_name.strip()
+        normalized_model_name = resolved_model_name.strip().lower()
         if normalized_model_name not in SUPPORTED_SHOTS_SLM_MODELS:
             supported_models = ", ".join(SUPPORTED_SHOTS_SLM_MODELS)
             raise ValueError(f"slm_model_name must be one of: {supported_models}.")

--- a/fabric_rti_mcp/services/kusto/kusto_service.py
+++ b/fabric_rti_mcp/services/kusto/kusto_service.py
@@ -10,7 +10,7 @@ import uuid
 from collections.abc import Callable
 from dataclasses import asdict
 from datetime import timedelta
-from typing import Any, Literal, TypeVar
+from typing import Any, TypeVar
 from urllib.parse import quote, urlparse
 
 from azure.kusto.data import ClientRequestProperties, KustoConnectionStringBuilder
@@ -18,7 +18,15 @@ from azure.kusto.data import ClientRequestProperties, KustoConnectionStringBuild
 from fabric_rti_mcp import __version__  # type: ignore
 from fabric_rti_mcp.auth.auth_context import TokenTarget, credential_source_cache_key, resolve_credential_source
 from fabric_rti_mcp.config import global_config, logger
-from fabric_rti_mcp.services.kusto.kusto_config import KustoConfig, KustoServiceConfig, normalize_service_uri_key
+from fabric_rti_mcp.services.kusto.kusto_config import (
+    SUPPORTED_SHOTS_EMBEDDING_METHODS,
+    SUPPORTED_SHOTS_SLM_MODELS,
+    KustoConfig,
+    KustoServiceConfig,
+    ShotsEmbeddingMethod,
+    ShotsSlmModel,
+    normalize_service_uri_key,
+)
 from fabric_rti_mcp.services.kusto.kusto_connection import KustoConnection, sanitize_uri
 from fabric_rti_mcp.services.kusto.kusto_formatter import KustoFormatter, KustoResponseFormat
 
@@ -928,14 +936,20 @@ def kusto_get_shots(
     database: str | None = None,
     embedding_endpoint: str | None = None,
     client_request_properties: dict[str, Any] | None = None,
-    embedding_method: Literal["slm", "aoai"] | None = None,
-    slm_model_name: str | None = None,
+    embedding_method: ShotsEmbeddingMethod | None = None,
+    slm_model_name: ShotsSlmModel | None = None,
 ) -> dict[str, Any]:
     """
     Find similar saved KQL queries.
 
     Semantic search returns existing query examples that are relevant to the user's
     prompt, so they can be used as starting points for similar requests.
+
+    SLM requires a deployed slm_embeddings_fl function and the Python plugin image.
+    Follow the Azure Data Explorer or Microsoft Fabric deployment instructions at
+    https://learn.microsoft.com/en-us/kusto/functions-library/slm-embeddings-fl.
+    Before selecting SLM, kusto_describe_database_entity can verify that the function
+    exists by using entity_name="slm_embeddings_fl" and entity_type="function".
 
     :param prompt: The user prompt to find similar shots for.
     :param shots_table_name: Name of the table containing the shots. The table should have "EmbeddingText" (string)
@@ -952,8 +966,10 @@ def kusto_get_shots(
     :param embedding_method: Embedding method for the prompt. "slm" invokes a pre-deployed slm_embeddings_fl
                              function in the queried database. "aoai" uses ai_embeddings and requires an embedding
                              endpoint. If not provided, uses KUSTO_SHOTS_EMBEDDING_METHOD, which defaults to "aoai".
-    :param slm_model_name: SLM model passed to slm_embeddings_fl. The shots table vectors must use the same model.
-                           If not provided, uses KUSTO_SHOTS_SLM_MODEL, which defaults to "harrier-v1-270m".
+    :param slm_model_name: SLM model passed to slm_embeddings_fl: "jina-v2-small" (512 dimensions),
+                           "e5-small-v2" (384), or "harrier-v1-270m" (640). The shots table vectors must use the
+                           same model. If not provided, uses KUSTO_SHOTS_SLM_MODEL, which defaults to
+                           "harrier-v1-270m".
     :return: List of dictionaries containing the shots records.
     """
     resolved_table = shots_table_name or CONFIG.shots_table
@@ -964,15 +980,17 @@ def kusto_get_shots(
 
     resolved_embedding_method = embedding_method if embedding_method is not None else CONFIG.shots_embedding_method
     normalized_embedding_method = resolved_embedding_method.strip().lower()
-    if normalized_embedding_method not in ("slm", "aoai"):
-        raise ValueError("embedding_method must be either 'slm' or 'aoai'.")
+    if normalized_embedding_method not in SUPPORTED_SHOTS_EMBEDDING_METHODS:
+        supported_methods = ", ".join(SUPPORTED_SHOTS_EMBEDDING_METHODS)
+        raise ValueError(f"embedding_method must be one of: {supported_methods}.")
 
     escaped_prompt = kql_escape_string(prompt)
     if normalized_embedding_method == "slm":
         resolved_model_name = slm_model_name if slm_model_name is not None else CONFIG.shots_slm_model
         normalized_model_name = resolved_model_name.strip()
-        if not normalized_model_name:
-            raise ValueError("slm_model_name must not be empty.")
+        if normalized_model_name not in SUPPORTED_SHOTS_SLM_MODELS:
+            supported_models = ", ".join(SUPPORTED_SHOTS_SLM_MODELS)
+            raise ValueError(f"slm_model_name must be one of: {supported_models}.")
 
         embedding_query = f"""
         let embedded_term = toscalar(

--- a/tests/live/test_kusto_tools_live.py
+++ b/tests/live/test_kusto_tools_live.py
@@ -585,19 +585,34 @@ class KustoToolsLiveTester:
             raise RuntimeError("Client not initialized")
 
         shots_table = os.getenv("KUSTO_LIVE_SHOTS_TABLE") or os.getenv("KUSTO_SHOTS_TABLE")
+        embedding_method = os.getenv("KUSTO_LIVE_SHOTS_EMBEDDING_METHOD", "aoai")
         embedding_endpoint = os.getenv("AZ_OPENAI_EMBEDDING_ENDPOINT")
+        slm_model_name = os.getenv("KUSTO_LIVE_SHOTS_SLM_MODEL", "harrier-v1-270m")
 
-        if shots_table and embedding_endpoint:
+        if shots_table and embedding_method:
+            normalized_method = embedding_method.strip().lower()
+            tool_arguments = {
+                "prompt": "Find a few storm events in Texas",
+                "cluster_uri": self.test_cluster_uri,
+                "database": self.test_database,
+                "shots_table_name": shots_table,
+                "embedding_method": normalized_method,
+                "sample_size": 1,
+            }
+
+            if normalized_method == "aoai":
+                if not embedding_endpoint:
+                    print("⚠️  Skipping AOAI kusto_get_shots call: AZ_OPENAI_EMBEDDING_ENDPOINT is not configured")
+                    return
+                tool_arguments["embedding_endpoint"] = embedding_endpoint
+            elif normalized_method == "slm":
+                tool_arguments["slm_model_name"] = slm_model_name
+            else:
+                raise ValueError("KUSTO_LIVE_SHOTS_EMBEDDING_METHOD must be 'slm' or 'aoai'")
+
             result = await self.client.call_tool(
                 "kusto_get_shots",
-                {
-                    "prompt": "Find a few storm events in Texas",
-                    "cluster_uri": self.test_cluster_uri,
-                    "database": self.test_database,
-                    "shots_table_name": shots_table,
-                    "embedding_endpoint": embedding_endpoint,
-                    "sample_size": 1,
-                },
+                tool_arguments,
             )
 
             if not result.get("success"):
@@ -606,10 +621,6 @@ class KustoToolsLiveTester:
             shots_result = self._payload(result)
             parsed_data = KustoFormatter.parse(shots_result) or []
             print(f"✅ kusto_get_shots returned {len(parsed_data)} shot(s)")
-            return
-
-        if shots_table and not embedding_endpoint:
-            print("⚠️  Skipping full kusto_get_shots call: AZ_OPENAI_EMBEDDING_ENDPOINT is not configured")
             return
 
         result = await self.client.call_tool(

--- a/tests/unit/kusto/test_kusto_get_shots.py
+++ b/tests/unit/kusto/test_kusto_get_shots.py
@@ -1,0 +1,211 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from fabric_rti_mcp.services.kusto.kusto_service import kusto_get_shots
+
+CLUSTER_URI = "https://help.kusto.windows.net"
+SHOTS_TABLE = "Shots"
+
+
+@patch("fabric_rti_mcp.services.kusto.kusto_service._execute")
+def test_get_shots_uses_aoai_by_default(mock_execute: MagicMock) -> None:
+    endpoint = "https://example.openai.azure.com/embeddings;impersonate"
+
+    kusto_get_shots(
+        "Find storms in Texas",
+        CLUSTER_URI,
+        shots_table_name=SHOTS_TABLE,
+        embedding_endpoint=endpoint,
+    )
+
+    query = mock_execute.call_args.args[0]
+    assert "ai_embeddings" in query
+    assert endpoint in query
+    assert "slm_embeddings_fl" not in query
+    assert "series_cosine_similarity(embedded_term, EmbeddingVector, 1.0, 1.0)" in query
+
+
+@patch("fabric_rti_mcp.services.kusto.kusto_service.CONFIG")
+@patch("fabric_rti_mcp.services.kusto.kusto_service._execute")
+def test_get_shots_uses_configured_slm_defaults(mock_execute: MagicMock, mock_config: MagicMock) -> None:
+    mock_config.shots_table = None
+    mock_config.shots_embedding_method = "slm"
+    mock_config.shots_slm_model = "harrier-v1-270m"
+
+    kusto_get_shots(
+        "Find storms in Texas",
+        CLUSTER_URI,
+        shots_table_name=SHOTS_TABLE,
+    )
+
+    query = mock_execute.call_args.args[0]
+    assert "slm_embeddings_fl" in query
+    assert "model_name='harrier-v1-270m'" in query
+    assert "ai_embeddings" not in query
+    assert "series_cosine_similarity(embedded_term, EmbeddingVector, 1.0, 1.0)" in query
+    assert mock_execute.call_args.kwargs["readonly_override"] is True
+
+
+@patch("fabric_rti_mcp.services.kusto.kusto_service._execute")
+def test_get_shots_uses_and_escapes_custom_slm_model(mock_execute: MagicMock) -> None:
+    kusto_get_shots(
+        "Find the user's storms",
+        CLUSTER_URI,
+        shots_table_name=SHOTS_TABLE,
+        embedding_method="slm",
+        slm_model_name="custom'model",
+    )
+
+    query = mock_execute.call_args.args[0]
+    assert "Find the user''s storms" in query
+    assert "model_name='custom''model'" in query
+
+
+@patch("fabric_rti_mcp.services.kusto.kusto_service._execute")
+def test_get_shots_rejects_explicit_empty_slm_model(mock_execute: MagicMock) -> None:
+    with pytest.raises(ValueError, match="slm_model_name must not be empty"):
+        kusto_get_shots(
+            "Find storms in Texas",
+            CLUSTER_URI,
+            shots_table_name=SHOTS_TABLE,
+            embedding_method="slm",
+            slm_model_name="",
+        )
+
+    mock_execute.assert_not_called()
+
+
+@patch("fabric_rti_mcp.services.kusto.kusto_service._execute")
+def test_get_shots_uses_aoai_when_explicitly_selected(mock_execute: MagicMock) -> None:
+    endpoint = "https://example.openai.azure.com/embeddings;impersonate"
+
+    kusto_get_shots(
+        "Find storms in Texas",
+        CLUSTER_URI,
+        shots_table_name=SHOTS_TABLE,
+        embedding_method="aoai",
+        embedding_endpoint=endpoint,
+    )
+
+    query = mock_execute.call_args.args[0]
+    assert "ai_embeddings" in query
+    assert endpoint in query
+    assert "slm_embeddings_fl" not in query
+    assert mock_execute.call_args.kwargs["readonly_override"] is False
+
+
+@patch("fabric_rti_mcp.services.kusto.kusto_service.CONFIG")
+@patch("fabric_rti_mcp.services.kusto.kusto_service._execute")
+def test_get_shots_aoai_uses_configured_endpoint(mock_execute: MagicMock, mock_config: MagicMock) -> None:
+    mock_config.shots_table = None
+    mock_config.open_ai_embedding_endpoint = "https://configured.openai.azure.com/embeddings;impersonate"
+
+    kusto_get_shots(
+        "Find storms in Texas",
+        CLUSTER_URI,
+        shots_table_name=SHOTS_TABLE,
+        embedding_method="aoai",
+    )
+
+    query = mock_execute.call_args.args[0]
+    assert mock_config.open_ai_embedding_endpoint in query
+
+
+@patch("fabric_rti_mcp.services.kusto.kusto_service.CONFIG")
+@patch("fabric_rti_mcp.services.kusto.kusto_service._execute")
+def test_get_shots_aoai_requires_endpoint(mock_execute: MagicMock, mock_config: MagicMock) -> None:
+    mock_config.shots_table = None
+    mock_config.shots_embedding_method = "aoai"
+    mock_config.open_ai_embedding_endpoint = None
+
+    with pytest.raises(ValueError, match="embedding_endpoint must be provided"):
+        kusto_get_shots(
+            "Find storms in Texas",
+            CLUSTER_URI,
+            shots_table_name=SHOTS_TABLE,
+        )
+
+    mock_execute.assert_not_called()
+
+
+@patch("fabric_rti_mcp.services.kusto.kusto_service._execute")
+def test_get_shots_slm_ignores_embedding_endpoint(mock_execute: MagicMock) -> None:
+    endpoint = "https://example.openai.azure.com/embeddings"
+
+    kusto_get_shots(
+        "Find storms in Texas",
+        CLUSTER_URI,
+        shots_table_name=SHOTS_TABLE,
+        embedding_endpoint=endpoint,
+        embedding_method="slm",
+    )
+
+    query = mock_execute.call_args.args[0]
+    assert "slm_embeddings_fl" in query
+    assert "ai_embeddings" not in query
+    assert endpoint not in query
+
+
+@patch("fabric_rti_mcp.services.kusto.kusto_service._execute")
+def test_get_shots_rejects_unknown_embedding_method(mock_execute: MagicMock) -> None:
+    with pytest.raises(ValueError, match="embedding_method must be either"):
+        kusto_get_shots(
+            "Find storms in Texas",
+            CLUSTER_URI,
+            shots_table_name=SHOTS_TABLE,
+            embedding_method="unsupported",  # type: ignore[arg-type]
+        )
+
+    mock_execute.assert_not_called()
+
+
+@patch("fabric_rti_mcp.services.kusto.kusto_service.CONFIG")
+@patch("fabric_rti_mcp.services.kusto.kusto_service._execute")
+def test_get_shots_requires_shots_table(mock_execute: MagicMock, mock_config: MagicMock) -> None:
+    mock_config.shots_table = None
+
+    with pytest.raises(ValueError, match="shots_table_name must be provided"):
+        kusto_get_shots("Find storms in Texas", CLUSTER_URI)
+
+    mock_execute.assert_not_called()
+
+
+@patch("fabric_rti_mcp.services.kusto.kusto_service._execute")
+def test_get_shots_forwards_execution_arguments(mock_execute: MagicMock) -> None:
+    request_properties = {"query_results_cache_max_age": "00:05:00"}
+
+    kusto_get_shots(
+        "Find storms in Texas",
+        CLUSTER_URI,
+        shots_table_name=SHOTS_TABLE,
+        database="Samples",
+        embedding_method="slm",
+        client_request_properties=request_properties,
+    )
+
+    mock_execute.assert_called_once()
+    assert mock_execute.call_args.args[1] == CLUSTER_URI
+    assert mock_execute.call_args.kwargs == {
+        "readonly_override": True,
+        "database": "Samples",
+        "client_request_properties": request_properties,
+    }
+
+
+@patch("fabric_rti_mcp.services.kusto.kusto_service._execute")
+def test_get_shots_preserves_client_request_properties_positional_argument(mock_execute: MagicMock) -> None:
+    request_properties = {"query_results_cache_max_age": "00:05:00"}
+    endpoint = "https://example.openai.azure.com/embeddings;impersonate"
+
+    kusto_get_shots(
+        "Find storms in Texas",
+        CLUSTER_URI,
+        SHOTS_TABLE,
+        3,
+        "Samples",
+        endpoint,
+        request_properties,
+    )
+
+    assert mock_execute.call_args.kwargs["client_request_properties"] is request_properties

--- a/tests/unit/kusto/test_kusto_get_shots.py
+++ b/tests/unit/kusto/test_kusto_get_shots.py
@@ -2,6 +2,11 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from fabric_rti_mcp.services.kusto.kusto_config import (
+    DEFAULT_SHOTS_SLM_MODEL,
+    SUPPORTED_SHOTS_SLM_MODELS,
+    ShotsSlmModel,
+)
 from fabric_rti_mcp.services.kusto.kusto_service import kusto_get_shots
 
 CLUSTER_URI = "https://help.kusto.windows.net"
@@ -31,7 +36,7 @@ def test_get_shots_uses_aoai_by_default(mock_execute: MagicMock) -> None:
 def test_get_shots_uses_configured_slm_defaults(mock_execute: MagicMock, mock_config: MagicMock) -> None:
     mock_config.shots_table = None
     mock_config.shots_embedding_method = "slm"
-    mock_config.shots_slm_model = "harrier-v1-270m"
+    mock_config.shots_slm_model = DEFAULT_SHOTS_SLM_MODEL
 
     kusto_get_shots(
         "Find storms in Texas",
@@ -47,30 +52,31 @@ def test_get_shots_uses_configured_slm_defaults(mock_execute: MagicMock, mock_co
     assert mock_execute.call_args.kwargs["readonly_override"] is True
 
 
+@pytest.mark.parametrize("model_name", SUPPORTED_SHOTS_SLM_MODELS)
 @patch("fabric_rti_mcp.services.kusto.kusto_service._execute")
-def test_get_shots_uses_and_escapes_custom_slm_model(mock_execute: MagicMock) -> None:
+def test_get_shots_uses_supported_slm_model(mock_execute: MagicMock, model_name: ShotsSlmModel) -> None:
     kusto_get_shots(
         "Find the user's storms",
         CLUSTER_URI,
         shots_table_name=SHOTS_TABLE,
         embedding_method="slm",
-        slm_model_name="custom'model",
+        slm_model_name=model_name,
     )
 
     query = mock_execute.call_args.args[0]
     assert "Find the user''s storms" in query
-    assert "model_name='custom''model'" in query
+    assert f"model_name='{model_name}'" in query
 
 
 @patch("fabric_rti_mcp.services.kusto.kusto_service._execute")
-def test_get_shots_rejects_explicit_empty_slm_model(mock_execute: MagicMock) -> None:
-    with pytest.raises(ValueError, match="slm_model_name must not be empty"):
+def test_get_shots_rejects_unsupported_slm_model(mock_execute: MagicMock) -> None:
+    with pytest.raises(ValueError, match="slm_model_name must be one of"):
         kusto_get_shots(
             "Find storms in Texas",
             CLUSTER_URI,
             shots_table_name=SHOTS_TABLE,
             embedding_method="slm",
-            slm_model_name="",
+            slm_model_name="unsupported",  # type: ignore[arg-type]
         )
 
     mock_execute.assert_not_called()
@@ -149,7 +155,7 @@ def test_get_shots_slm_ignores_embedding_endpoint(mock_execute: MagicMock) -> No
 
 @patch("fabric_rti_mcp.services.kusto.kusto_service._execute")
 def test_get_shots_rejects_unknown_embedding_method(mock_execute: MagicMock) -> None:
-    with pytest.raises(ValueError, match="embedding_method must be either"):
+    with pytest.raises(ValueError, match="embedding_method must be one of"):
         kusto_get_shots(
             "Find storms in Texas",
             CLUSTER_URI,

--- a/tests/unit/kusto/test_kusto_service.py
+++ b/tests/unit/kusto/test_kusto_service.py
@@ -188,6 +188,21 @@ def test_kusto_known_services_probe_mode_env_overrides_default() -> None:
     assert config.should_probe_known_services(CredentialSource.LOCAL_DEVELOPER) is True
 
 
+@patch.dict(
+    "os.environ",
+    {
+        "KUSTO_SHOTS_EMBEDDING_METHOD": "slm",
+        "KUSTO_SHOTS_SLM_MODEL": "harrier-v1-270m",
+    },
+    clear=True,
+)
+def test_kusto_shots_embedding_defaults_load_from_env() -> None:
+    config = KustoConfig.from_env()
+
+    assert config.shots_embedding_method == "slm"
+    assert config.shots_slm_model == "harrier-v1-270m"
+
+
 @patch.dict("os.environ", {"FABRIC_RTI_KUSTO_RESPONSE_FORMAT": "full_kusto_response"}, clear=True)
 def test_response_format_env_accepts_full_kusto_response() -> None:
     config = KustoConfig.from_env()

--- a/tests/unit/kusto/test_kusto_service.py
+++ b/tests/unit/kusto/test_kusto_service.py
@@ -7,7 +7,11 @@ from azure.kusto.data.response import KustoResponseDataSet
 
 from fabric_rti_mcp import __version__
 from fabric_rti_mcp.auth.auth_context import CredentialSource
-from fabric_rti_mcp.services.kusto.kusto_config import KustoConfig
+from fabric_rti_mcp.services.kusto.kusto_config import (
+    DEFAULT_SHOTS_EMBEDDING_METHOD,
+    DEFAULT_SHOTS_SLM_MODEL,
+    KustoConfig,
+)
 from fabric_rti_mcp.services.kusto.kusto_service import (
     KustoConnectionManager,
     kusto_command,
@@ -200,7 +204,15 @@ def test_kusto_shots_embedding_defaults_load_from_env() -> None:
     config = KustoConfig.from_env()
 
     assert config.shots_embedding_method == "slm"
-    assert config.shots_slm_model == "harrier-v1-270m"
+    assert config.shots_slm_model == DEFAULT_SHOTS_SLM_MODEL
+
+
+@patch.dict("os.environ", {}, clear=True)
+def test_kusto_shots_embedding_defaults_are_centralized() -> None:
+    config = KustoConfig.from_env()
+
+    assert config.shots_embedding_method == DEFAULT_SHOTS_EMBEDDING_METHOD
+    assert config.shots_slm_model == DEFAULT_SHOTS_SLM_MODEL
 
 
 @patch.dict("os.environ", {"FABRIC_RTI_KUSTO_RESPONSE_FORMAT": "full_kusto_response"}, clear=True)

--- a/tests/unit/kusto/test_kusto_service.py
+++ b/tests/unit/kusto/test_kusto_service.py
@@ -195,16 +195,16 @@ def test_kusto_known_services_probe_mode_env_overrides_default() -> None:
 @patch.dict(
     "os.environ",
     {
-        "KUSTO_SHOTS_EMBEDDING_METHOD": "slm",
-        "KUSTO_SHOTS_SLM_MODEL": "harrier-v1-270m",
+        "KUSTO_SHOTS_EMBEDDING_METHOD": " SLM ",
+        "KUSTO_SHOTS_SLM_MODEL": " E5-SMALL-V2 ",
     },
     clear=True,
 )
-def test_kusto_shots_embedding_defaults_load_from_env() -> None:
+def test_kusto_shots_embedding_settings_load_normalized_env_overrides() -> None:
     config = KustoConfig.from_env()
 
     assert config.shots_embedding_method == "slm"
-    assert config.shots_slm_model == DEFAULT_SHOTS_SLM_MODEL
+    assert config.shots_slm_model == "e5-small-v2"
 
 
 @patch.dict("os.environ", {}, clear=True)
@@ -213,6 +213,19 @@ def test_kusto_shots_embedding_defaults_are_centralized() -> None:
 
     assert config.shots_embedding_method == DEFAULT_SHOTS_EMBEDDING_METHOD
     assert config.shots_slm_model == DEFAULT_SHOTS_SLM_MODEL
+
+
+@pytest.mark.parametrize(
+    ("env_name", "env_value"),
+    [
+        ("KUSTO_SHOTS_EMBEDDING_METHOD", "unsupported"),
+        ("KUSTO_SHOTS_SLM_MODEL", "unsupported"),
+    ],
+)
+def test_kusto_shots_embedding_settings_reject_invalid_env_values(env_name: str, env_value: str) -> None:
+    with patch.dict("os.environ", {env_name: env_value}, clear=True):
+        with pytest.raises(ValueError, match=rf"Invalid {env_name}=.*Expected one of"):
+            KustoConfig.from_env()
 
 
 @patch.dict("os.environ", {"FABRIC_RTI_KUSTO_RESPONSE_FORMAT": "full_kusto_response"}, clear=True)

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -116,6 +116,15 @@ def test_get_shots_registration_metadata(monkeypatch: pytest.MonkeyPatch) -> Non
 
     assert get_shots.description is not None
     assert get_shots.description.strip().splitlines()[0] == "Find similar saved KQL queries."
+    assert "https://learn.microsoft.com/en-us/kusto/functions-library/slm-embeddings-fl" in get_shots.description
+    embedding_method_options = get_shots.inputSchema["properties"]["embedding_method"]["anyOf"]
+    slm_model_options = get_shots.inputSchema["properties"]["slm_model_name"]["anyOf"]
+    assert next(option["enum"] for option in embedding_method_options if "enum" in option) == ["slm", "aoai"]
+    assert next(option["enum"] for option in slm_model_options if "enum" in option) == [
+        "jina-v2-small",
+        "e5-small-v2",
+        "harrier-v1-270m",
+    ]
     assert get_shots.annotations is not None
     assert get_shots.annotations.readOnlyHint is True
 


### PR DESCRIPTION
## Summary
- add configurable SLM embedding support to `kusto_get_shots` through a pre-deployed `slm_embeddings_fl` 
- preserve Azure OpenAI compatibility while allowing server-level provider and SLM model defaults
- optimize cosine ranking for normalized vectors and allow SLM artifact callouts
- document supported models, deployment requirements, and VS Code debugger attachment workflows

## Testing
- `ruff check fabric_rti_mcp`
- `ty check fabric_rti_mcp`
- `pytest -q` (242 passed)
- live AOAI and Harrier SLM shot retrieval against `demo12/AI`